### PR TITLE
Handle the change of ChangeShardState parcel format

### DIFF
--- a/src/core/Parcel.ts
+++ b/src/core/Parcel.ts
@@ -33,7 +33,7 @@ export class Parcel {
     action: Action;
 
     static transactions(nonce: U256, fee: U256, networkId: number, ...transactions: Transaction[]): Parcel {
-        const action = new ChangeShardState(transactions);
+        const action = new ChangeShardState({ transactions });
         return new Parcel(nonce, fee, networkId, action);
     }
 

--- a/src/core/__test__/Parcel.spec.ts
+++ b/src/core/__test__/Parcel.spec.ts
@@ -5,27 +5,27 @@ import { Parcel } from "../Parcel";
 
 test("rlp", () => {
     const t = Parcel.transactions(new U256(0), new U256(0), 1);
-    expect(t.rlpBytes()).toEqual(Buffer.from([0xc6, 0x80, 0x80, 0x01, 0xC2, 0x01, 0xC0]));
+    expect(t.rlpBytes()).toEqual(Buffer.from([248, 78, 128, 128, 1, 248, 73, 1, 192, 248, 69, 248, 67, 128, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
 });
 
 test("hash", () => {
     const t = Parcel.transactions(new U256(0), new U256(0), 1);
-    expect(t.hash()).toEqual(new H256("793ab19e6663f78a1ac52e440347b8efe0d74318eccee020972a25adb926b3fa"));
+    expect(t.hash()).toEqual(new H256("78850c22e15642a364d57c2a9e5df97bb2876ee32fdf93da1e11afcd2d586245"));
 });
 
 test("sign", () => {
     const t = Parcel.transactions(new U256(0), new U256(0), 1);
     const signed = t.sign(new H256("ede1d4ccb4ec9a8bbbae9a13db3f4a7b56ea04189be86ac3a6a439d9a0a1addd"));
     const { v, r, s } = signed.signature();
-    expect(v).toBe(0);
-    expect(r).toEqual(new U256("0x3824b636cd92324253b13bcb7c674ecb44e7dbb22cd438c39a5529cd2a923e0b"));
-    expect(s).toEqual(new U256("0x1691d9f073d407f71e5f0ca6450b6f206a6ddb97a9ee22951ec1d75eff4d30e6"));
+    expect(v).toBe(1);
+    expect(r).toEqual(new U256("0x4ec506266b9945c152b325d8155c6ee05b9602272a87c0f9bf6180495e0c0cc1"));
+    expect(s).toEqual(new U256("0x4e1c05949e04cec49db5185f0f6dbfcc56ac83a1eae3fb6d45ae4b60d382ca3d"));
 });
 
 test("signed hash", () => {
     const t = Parcel.transactions(new U256(0), new U256(0), 1);
     const signed = t.sign(new H256("ede1d4ccb4ec9a8bbbae9a13db3f4a7b56ea04189be86ac3a6a439d9a0a1addd"));
-    expect(signed.hash()).toEqual(new H256("8f5b65f7cfda422147dcd8402f9e95b401710a54c16eeb2feb5110648e466747"));
+    expect(signed.hash()).toEqual(new H256("ec67fb2529da6f438d5bbf45c8025bcbcfa4d87c2d6ca2b36a25501e3cadc665"));
 });
 
 test("toJSON", () => {

--- a/src/core/action/Action.ts
+++ b/src/core/action/Action.ts
@@ -15,7 +15,7 @@ export function getActionFromJSON(json: any): Action {
     switch (action) {
         case "changeShardState":
             const { transactions } = json;
-            return new ChangeShardState(transactions.map(getTransactionFromJSON));
+            return new ChangeShardState({ transactions: transactions.map(getTransactionFromJSON) });
         case "payment":
             const { receiver, amount } = json;
             return new Payment(new H160(receiver), new U256(amount));

--- a/src/core/action/ChangeShardState.ts
+++ b/src/core/action/ChangeShardState.ts
@@ -1,20 +1,53 @@
 import { Transaction } from "../transaction/Transaction";
+import { H256 } from "../H256";
+
+export class ChangeShard {
+    public shard_id: number;
+    public pre_root: H256;
+    public post_root: H256;
+
+    constructor(obj: { shard_id: number, pre_root: H256, post_root: H256 }) {
+        this.shard_id = obj.shard_id;
+        this.pre_root = obj.pre_root;
+        this.post_root = obj.post_root;
+    }
+
+    toJSON() {
+        const { shard_id, pre_root, post_root } = this;
+        return {
+            shard_id,
+            pre_root,
+            post_root
+        };
+    }
+
+    toEncodeObject() {
+        const { shard_id, pre_root, post_root } = this;
+        return [shard_id, pre_root.toEncodeObject(), post_root.toEncodeObject()];
+    }
+}
 
 export class ChangeShardState {
     transactions: Transaction[];
+    changes: ChangeShard[];
 
-    constructor(transactions: Transaction[]) {
-        this.transactions = transactions;
+    constructor(input: { transactions: Transaction[] }) {
+        const ZERO = new H256("0x0000000000000000000000000000000000000000000000000000000000000000")
+        this.transactions = input.transactions;
+        this.changes = [new ChangeShard({ shard_id: 0, pre_root: ZERO, post_root: ZERO })];
     }
 
     toEncodeObject(): Array<any> {
-        return [1, this.transactions.map(transaction => transaction.toEncodeObject())];
+        const transactions = this.transactions.map(transaction => transaction.toEncodeObject());
+        const changes = this.changes.map(c => c.toEncodeObject());
+        return [1, transactions, changes];
     }
 
     toJSON() {
         return {
             action: "changeShardState",
-            transactions: this.transactions.map(t => t.toJSON())
+            transactions: this.transactions.map(t => t.toJSON()),
+            changes: this.changes.map(c => c.toJSON())
         };
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -96,7 +96,7 @@ export class Core {
      */
     createChangeShardStateParcel(params: { transactions: Transaction[] } & ParcelParams): Parcel {
         const { transactions, nonce, fee } = params;
-        const action = new ChangeShardState(transactions);
+        const action = new ChangeShardState({ transactions });
         return new Parcel(
             U256.ensure(nonce),
             U256.ensure(fee),


### PR DESCRIPTION
CodeChain changes the parcel format to support sharding.

But this patch doesn't change the API, makes all ChangeShardState
parcels will be executed in the first shard.