### PR TITLE
Make ShardId 16 bits

### DIFF
--- a/src/__test__/blake.spec.ts
+++ b/src/__test__/blake.spec.ts
@@ -1,0 +1,12 @@
+import { blake208, blake256 } from "../utils";
+
+test("result of blake256 is 64 hex decimal", () => {
+    const hash = blake256("some string");
+    expect(hash.length).toBe(64);
+});
+
+
+test("result of blake208 is 64 hex decimal", () => {
+    const hash = blake208("some string");
+    expect(hash.length).toBe(52);
+});

--- a/src/core/transaction/AssetMintTransaction.ts
+++ b/src/core/transaction/AssetMintTransaction.ts
@@ -4,7 +4,7 @@ import { PlatformAddress } from "../../key/classes";
 
 import { H160 } from "../H160";
 import { H256 } from "../H256";
-import { blake256WithKey, blake256 } from "../../utils";
+import { blake208WithKey, blake256 } from "../../utils";
 import { Asset } from "../Asset";
 import { AssetScheme } from "../AssetScheme";
 
@@ -148,31 +148,31 @@ export class AssetMintTransaction {
 
     getAssetSchemeAddress(): H256 {
         const { shardId } = this;
-        const blake = blake256WithKey(this.hash().value, new Uint8Array([
+        const blake = blake208WithKey(this.hash().value, new Uint8Array([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         ]));
-        const shardPrefix = convertU32toHex(shardId);
-        const prefix = `53000000${shardPrefix}`;
-        return new H256(blake.replace(new RegExp(`^.{${prefix.length}}`), prefix));
+        const shardPrefix = convertU16toHex(shardId);
+        const worldPrefix = "0000";
+        const prefix = "5300";
+        return new H256(prefix + shardPrefix + worldPrefix + blake);
     }
 
     getAssetAddress(): H256 {
         const { shardId } = this;
-        const blake = blake256WithKey(this.hash().value, new Uint8Array([
+        const blake = blake208WithKey(this.hash().value, new Uint8Array([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ]));
-        const shardPrefix = convertU32toHex(shardId);
-        const prefix = `41000000${shardPrefix}`;
-        return new H256(blake.replace(new RegExp(`^.{${prefix.length}}`), prefix));
+        const shardPrefix = convertU16toHex(shardId);
+        const worldPrefix = "0000";
+        const prefix = "4100";
+        return new H256(prefix + shardPrefix + worldPrefix + blake);
     }
 }
 
-function convertU32toHex(id: number) {
-    const shardId0: string = ("0" + ((id >> 24) & 0xFF).toString(16)).slice(-2);
-    const shardId1: string = ("0" + ((id >> 16) & 0xFF).toString(16)).slice(-2);
-    const shardId2: string = ("0" + ((id >> 8) & 0xFF).toString(16)).slice(-2);
-    const shardId3: string = ("0" + ((id >> 0) & 0xFF).toString(16)).slice(-2);
-    return shardId0 + shardId1 + shardId2 + shardId3;
+function convertU16toHex(id: number) {
+    const hi: string = ("0" + ((id >> 8) & 0xFF).toString(16)).slice(-2);
+    const lo: string = ("0" + (id & 0xFF).toString(16)).slice(-2);
+    return hi + lo;
 }

--- a/src/core/transaction/AssetTransferOutput.ts
+++ b/src/core/transaction/AssetTransferOutput.ts
@@ -57,6 +57,6 @@ export class AssetTransferOutput {
 
     shardId(): number {
         const { assetType } = this;
-        return parseInt(assetType.value.slice(8, 16), 16);
+        return parseInt(assetType.value.slice(4, 8), 16);
     }
 }

--- a/src/core/transaction/AssetTransferTransaction.ts
+++ b/src/core/transaction/AssetTransferTransaction.ts
@@ -3,7 +3,7 @@ import * as _ from "lodash";
 import { AssetTransferAddress } from "../../key/classes";
 
 import { H256 } from "../H256";
-import { blake256WithKey, blake256 } from "../../utils";
+import { blake208WithKey, blake256 } from "../../utils";
 import { AssetTransferInput } from "./AssetTransferInput";
 import { AssetTransferOutput } from "./AssetTransferOutput";
 import { Asset } from "../Asset";
@@ -171,9 +171,13 @@ export class AssetTransferTransaction {
             (index >> 56) & 0xFF, (index >> 48) & 0xFF, (index >> 40) & 0xFF, (index >> 32) & 0xFF,
             (index >> 24) & 0xFF, (index >> 16) & 0xFF, (index >> 8) & 0xFF, index & 0xFF,
         ]);
-        const blake = blake256WithKey(this.hash().value, iv);
-        const prefix = "4100000000000000";
-        return new H256(blake.replace(new RegExp(`^.{${prefix.length}}`), prefix));
+        const shardId = this.outputs[index].shardId();
+
+        const blake = blake208WithKey(this.hash().value, iv);
+        const shardPrefix = convertU16toHex(shardId);
+        const worldPrefix = "0000";
+        const prefix = "4100";
+        return new H256(prefix + shardPrefix + worldPrefix + blake);
     }
 
     static fromJSON(obj: any) {
@@ -201,4 +205,10 @@ export class AssetTransferTransaction {
             }
         };
     }
+}
+
+function convertU16toHex(id: number) {
+    const hi: string = ("0" + ((id >> 8) & 0xFF).toString(16)).slice(-2);
+    const lo: string = ("0" + (id & 0xFF).toString(16)).slice(-2);
+    return hi + lo;
 }

--- a/src/core/transaction/__test__/AssetTransferTransaction.spec.ts
+++ b/src/core/transaction/__test__/AssetTransferTransaction.spec.ts
@@ -88,8 +88,8 @@ test("AssetTransferOutput shard id", () => {
     const output = new AssetTransferOutput({
         lockScriptHash: new H256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         parameters: [Buffer.from([0x04, 0x05]), Buffer.from([0x06])],
-        assetType: new H256("41000000CAFEBEEFbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        assetType: new H256("4100BAADCAFEBEEFbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
         amount: 321
     });
-    expect(output.shardId()).toEqual(parseInt("CafeBeef", 16));
+    expect(output.shardId()).toEqual(parseInt("BAAD", 16));
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,6 +40,20 @@ export const blake256 = (data: Buffer | string): string => {
 };
 
 /**
+ * Gets data's 208 bit blake hash.
+ * @param data buffer or hexadecimal string
+ * @returns 26 byte hexadecimal string
+ */
+export const blake208 = (data: Buffer | string): string => {
+    if (!(data instanceof Buffer)) {
+        data = Buffer.from(data, "hex");
+    }
+    const context = blake.blake2bInit(26, null);
+    blake.blake2bUpdate(context, data);
+    return toHex(blake.blake2bFinal(context));
+};
+
+/**
  * Gets data's 256 bit blake hash by using the key.
  * @param data buffer or hexadecimal string
  * @param key
@@ -50,6 +64,21 @@ export const blake256WithKey = (data: Buffer | string, key: Uint8Array): string 
         data = Buffer.from(data, "hex");
     }
     const context = blake.blake2bInit(32, key);
+    blake.blake2bUpdate(context, data);
+    return toHex(blake.blake2bFinal(context));
+};
+
+/**
+ * Gets data's 208 bit blake hash by using the key.
+ * @param data buffer or hexadecimal string
+ * @param key
+ * @returns 26 byte hexadecimal string
+ */
+export const blake208WithKey = (data: Buffer | string, key: Uint8Array): string => {
+    if (!(data instanceof Buffer)) {
+        data = Buffer.from(data, "hex");
+    }
+    const context = blake.blake2bInit(26, key);
     blake.blake2bUpdate(context, data);
     return toHex(blake.blake2bFinal(context));
 };


### PR DESCRIPTION
This PR makes ShardId 16 bits and changes the mechanism to create asset/asset scheme address.
Currently, CodeChain generates 256 bits hash and replaces some bits with prefix and shard id and world id.
This patch changes CodeChain generates 208 bits hash instead of 256 bits hash since 48 bits will be removed.