### PR TITLE
Make test print more readable error message

### DIFF
--- a/src/core/__test__/Parcel.spec.ts
+++ b/src/core/__test__/Parcel.spec.ts
@@ -26,8 +26,8 @@ test("sign", () => {
     });
     const { v, r, s } = signed.signature();
     expect(v).toBe(1);
-    expect(r).toEqual(new U256("0x4ec506266b9945c152b325d8155c6ee05b9602272a87c0f9bf6180495e0c0cc1"));
-    expect(s).toEqual(new U256("0x4e1c05949e04cec49db5185f0f6dbfcc56ac83a1eae3fb6d45ae4b60d382ca3d"));
+    expect(r.toEncodeObject()).toEqual(new U256("0x4ec506266b9945c152b325d8155c6ee05b9602272a87c0f9bf6180495e0c0cc1").toEncodeObject());
+    expect(s.toEncodeObject()).toEqual(new U256("0x4e1c05949e04cec49db5185f0f6dbfcc56ac83a1eae3fb6d45ae4b60d382ca3d").toEncodeObject());
 });
 
 test("signed hash", () => {


### PR DESCRIPTION
The original error message:
```
    Expected value to equal:
      {"value": "2.226782094221477621952554244921253193664730740684574719043157109127753285836e+75"}
    Received:
      {"value": "3.5628513507543641951240867918740051098635691850953195504690513746044052573377e+76"}
```
The modified error message:
```
    Expected value to equal:
      "0x04ec506266b9945c152b325d8155c6ee05b9602272a87c0f9bf6180495e0c0cc"
    Received:
      "0x4ec506266b9945c152b325d8155c6ee05b9602272a87c0f9bf6180495e0c0cc1"
```