### PR TITLE
Make tslint's array-type option to false

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,8 @@
         "object-literal-sort-keys": false,
         "no-var-requires": false,
         "max-classes-per-file": false,
-        "no-bitwise": false
+        "no-bitwise": false,
+        "array-type": false
     },
     "jsRules": {
         "no-console": false,


### PR DESCRIPTION
After this commit we can use T[] type instead of Array<T>