### PR TITLE
Remove AccountRpc::remove method

### DIFF
--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -587,38 +587,6 @@ describe("rpc", () => {
             });
         });
 
-        describe("remove", () => {
-            let address;
-            beforeEach(async () => {
-                address = await sdk.rpc.account.create("123");
-            });
-
-            test("Ok", async () => {
-                await sdk.rpc.account.remove(address, "123");
-                expect(await sdk.rpc.account.getList()).not.toContain(address);
-            });
-
-            test("WrongPassword", async done => {
-                sdk.rpc.account
-                    .remove(address, "1234")
-                    .then(() => done.fail())
-                    .catch(e => {
-                        expect(e).toEqual(ERROR.WRONG_PASSWORD);
-                        done();
-                    });
-            });
-
-            test("NoSuchAccount", async done => {
-                sdk.rpc.account
-                    .remove(noSuchAccount, "123")
-                    .then(() => done.fail())
-                    .catch(e => {
-                        expect(e).toEqual(ERROR.NO_SUCH_ACCOUNT);
-                        done();
-                    });
-            });
-        });
-
         describe("sign", () => {
             const message =
                 "0000000000000000000000000000000000000000000000000000000000000000";

--- a/src/rpc/__test__/invalid-response.spec.ts
+++ b/src/rpc/__test__/invalid-response.spec.ts
@@ -437,19 +437,6 @@ describe("Invalid response", () => {
                 done.fail("not implemented"));
         });
 
-        test("remove", done => {
-            rpc.sendRpcRequest = jest.fn().mockResolvedValueOnce(undefined);
-            accountRpc
-                .remove(address)
-                .then(() => done.fail())
-                .catch(e => {
-                    expect(e.toString()).toContain("account_remove");
-                    expect(e.toString()).toContain("null");
-                    expect(e.toString()).toContain("undefined");
-                    done();
-                });
-        });
-
         describe("sign", () => {
             test("undefined", done => {
                 rpc.sendRpcRequest = jest.fn().mockResolvedValueOnce(undefined);

--- a/src/rpc/account.ts
+++ b/src/rpc/account.ts
@@ -119,45 +119,6 @@ export class AccountRpc {
     }
 
     /**
-     * Removes the account.
-     * @param address A platform address
-     * @param passphrase The account's passphrase
-     */
-    public remove(
-        address: PlatformAddress | string,
-        passphrase?: string
-    ): Promise<null> {
-        if (!PlatformAddress.check(address)) {
-            throw Error(
-                `Expected the first argument to be a PlatformAddress value but found ${address}`
-            );
-        }
-        if (passphrase && typeof passphrase !== "string") {
-            throw Error(
-                `Expected the second argument to be a string but found ${passphrase}`
-            );
-        }
-        return new Promise((resolve, reject) => {
-            this.rpc
-                .sendRpcRequest("account_remove", [
-                    PlatformAddress.ensure(address).toString(),
-                    passphrase
-                ])
-                .then(result => {
-                    if (result === null) {
-                        return resolve(null);
-                    }
-                    reject(
-                        Error(
-                            `Expected account_remove to return null but it returned ${result}`
-                        )
-                    );
-                })
-                .catch(reject);
-        });
-    }
-
-    /**
      * Calculates the account's signature for a given message.
      * @param messageDigest A message to sign
      * @param address A platform address


### PR DESCRIPTION
account_remove RPC API is removed from CodeChain.