### PR TITLE
Fix toEncodeObject() of AssetMintTransaction

### DIFF
--- a/src/core/transaction/AssetMintTransaction.ts
+++ b/src/core/transaction/AssetMintTransaction.ts
@@ -168,7 +168,7 @@ export class AssetMintTransaction {
             metadata,
             lockScriptHash.toEncodeObject(),
             parameters.map(parameter => Buffer.from(parameter)),
-            amount ? [amount] : [],
+            amount !== null ? [amount] : [],
             registrar ? [registrar.getAccountId().toEncodeObject()] : [],
             nonce
         ];


### PR DESCRIPTION
It should pass [0] when the amount is 0.