### PR TITLE
Use 160 bits blake2b to generate an account address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ node_js:
 before_install:
   - yarn install
 before_script:
-  - docker pull kodebox/codechain:876cfd559f8b4883595d9bbf3571be13afea91c5
-  - docker run -d -p 8080:8080 kodebox/codechain:876cfd559f8b4883595d9bbf3571be13afea91c5 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
+  - docker pull kodebox/codechain:ccbf2e8e6e9a6e12671ace0c42d936a545aa8218
+  - docker run -d -p 8080:8080 kodebox/codechain:ccbf2e8e6e9a6e12671ace0c42d936a545aa8218 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
   - docker ps -a
 script:
   - yarn test --verbose

--- a/examples/chain-send-parcel.js
+++ b/examples/chain-send-parcel.js
@@ -7,11 +7,11 @@ var sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 var parcel = sdk.core.createPaymentParcel({
-    recipient: "tccqruq09sfgax77nj4gukjcuq69uzeyv0jcs7vzngg",
+    recipient: "tccqxv9y4cw0jwphhu65tn4605wadyd2sxu5yezqghw",
     amount: 10000
 });
 

--- a/examples/get-balance.js
+++ b/examples/get-balance.js
@@ -7,7 +7,7 @@ var sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 
 sdk.rpc.chain
     .getBalance(ACCOUNT_ADDRESS)

--- a/examples/import-test-account.js
+++ b/examples/import-test-account.js
@@ -13,7 +13,7 @@ var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 sdk.rpc.account
     .importRaw(ACCOUNT_SECRET, ACCOUNT_PASSPHRASE)
     .then(function(account) {
-        console.log(account); // tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78
+        console.log(account); // tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd
     })
     .catch(e => {
         if (e.message !== "Already Exists") {

--- a/examples/mint-and-burn.js
+++ b/examples/mint-and-burn.js
@@ -7,7 +7,7 @@ const sdk = new SDK({
 
 const ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 const ACCOUNT_PASSPHRASE = "satoshi";
 
 (async () => {

--- a/examples/mint-and-transfer.js
+++ b/examples/mint-and-transfer.js
@@ -7,13 +7,13 @@ const sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 (async () => {
     const aliceAddress = await sdk.key.createAssetTransferAddress();
     const bobAddress =
-        "tcaqqq9pgkq69z488qlkvhkpcxcgfd3cqlkzgxyq9cewxuda8qqz7jtlvctt5eze";
+        "tcaqqqeqq47kh5nlk67eua0w2k4tku2hm0hazqx5wa3eqaaslq7zdfxhwgxs0x2r";
 
     // Create asset named Gold. Total amount of Gold is 10000. The registrar is set
     // to null, which means this type of asset can be transferred freely.

--- a/examples/mint-asset.js
+++ b/examples/mint-asset.js
@@ -7,13 +7,13 @@ var sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 // If you want to know how to create an address, see the example "Create an
 // asset transfer address".
 var address =
-    "tcaqqq9pgkq69z488qlkvhkpcxcgfd3cqlkzgxyq9cewxuda8qqz7jtlvctt5eze";
+    "tcaqqqeqq47kh5nlk67eua0w2k4tku2hm0hazqx5wa3eqaaslq7zdfxhwgxs0x2r";
 
 var assetMintTransaction = sdk.core.createAssetMintTransaction({
     scheme: {

--- a/examples/send-parcel.js
+++ b/examples/send-parcel.js
@@ -7,11 +7,11 @@ var sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 var parcel = sdk.core.createPaymentParcel({
-    recipient: "tccqruq09sfgax77nj4gukjcuq69uzeyv0jcs7vzngg",
+    recipient: "tccqxv9y4cw0jwphhu65tn4605wadyd2sxu5yezqghw",
     amount: 10000
 });
 

--- a/examples/send-signed-parcel-with-keystore.js
+++ b/examples/send-signed-parcel-with-keystore.js
@@ -6,7 +6,7 @@ var sdk = new SDK({
 });
 
 var parcel = sdk.core.createPaymentParcel({
-    recipient: "tccqruq09sfgax77nj4gukjcuq69uzeyv0jcs7vzngg",
+    recipient: "tccqxv9y4cw0jwphhu65tn4605wadyd2sxu5yezqghw",
     amount: 10000
 });
 

--- a/examples/send-signed-parcel.js
+++ b/examples/send-signed-parcel.js
@@ -10,10 +10,10 @@ var ACCOUNT_SECRET =
     "ede1d4ccb4ec9a8bbbae9a13db3f4a7b56ea04189be86ac3a6a439d9a0a1addd";
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 
 var parcel = sdk.core.createPaymentParcel({
-    recipient: "tccqruq09sfgax77nj4gukjcuq69uzeyv0jcs7vzngg",
+    recipient: "tccqxv9y4cw0jwphhu65tn4605wadyd2sxu5yezqghw",
     amount: 10000
 });
 

--- a/examples/unlock-and-send-parcel.js
+++ b/examples/unlock-and-send-parcel.js
@@ -7,11 +7,11 @@ var sdk = new SDK({
 
 var ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+    "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 var ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 var parcel = sdk.core.createPaymentParcel({
-    recipient: "tccqruq09sfgax77nj4gukjcuq69uzeyv0jcs7vzngg",
+    recipient: "tccqxv9y4cw0jwphhu65tn4605wadyd2sxu5yezqghw",
     amount: 10000
 });
 

--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -157,8 +157,8 @@ describe("rpc", () => {
         });
 
         describe("with account", () => {
-            const account = "0xa6594b7196808d161b6fb137e781abbc251385d9";
-            const address = "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78";
+            const account = "0x6fe64ffa3a46c074226457c90ccb32dc06ccced1";
+            const address = "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd";
 
             test("PlatformAddress", () => {
                 expect(
@@ -181,7 +181,7 @@ describe("rpc", () => {
 
             describe("has regular key", () => {
                 const regularKey =
-                    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+                    "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b";
 
                 beforeAll(async () => {
                     const parcel = sdk.core
@@ -561,7 +561,7 @@ describe("rpc", () => {
     });
 
     describe("account", () => {
-        const noSuchAccount = "tccqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj5aqu5";
+        const noSuchAccount = "tccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhhn9p3";
 
         test("getList", async () => {
             await expect(sdk.rpc.account.getList()).resolves.toEqual(

--- a/integration_tests/examples.spec.ts
+++ b/integration_tests/examples.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync, unlinkSync, writeFileSync } from "fs";
 
 describe("examples", () => {
     beforeAll(done => {
-        // import account "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78" which is used in
+        // import account "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd" which is used in
         // the examples.
         // The passphrase of the account is "satoshi".
         runExample("import-test-account", done);

--- a/integration_tests/helper.ts
+++ b/integration_tests/helper.ts
@@ -14,10 +14,10 @@ export const ACCOUNT_SECRET =
     "ede1d4ccb4ec9a8bbbae9a13db3f4a7b56ea04189be86ac3a6a439d9a0a1addd";
 export const ACCOUNT_ID =
     process.env.ACCOUNT_ID ||
-    sdk.util.getAccountIdFromPrivate(ACCOUNT_SECRET).toString(); // "0xa6594b7196808d161b6fb137e781abbc251385d9"
+    sdk.util.getAccountIdFromPrivate(ACCOUNT_SECRET).toString(); // "0x6fe64ffa3a46c074226457c90ccb32dc06ccced1"
 export const ACCOUNT_ADDRESS =
     process.env.ACCOUNT_ADDRESS ||
-    sdk.core.classes.PlatformAddress.fromAccountId(ACCOUNT_ID).toString(); // "tccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9my9a2k78"
+    sdk.core.classes.PlatformAddress.fromAccountId(ACCOUNT_ID).toString(); // "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd"
 export const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 export const sendTransactions = async ({ transactions }: any) => {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "dependencies": {
     "buffer": "5.1.0",
-    "codechain-keystore": "~0.2.1",
-    "codechain-primitives": "^0.1.0-rc2",
+    "codechain-keystore": "~0.2.2",
+    "codechain-primitives": "^0.2.0",
     "jayson": "^2.0.6",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",

--- a/src/core/SignedParcel.ts
+++ b/src/core/SignedParcel.ts
@@ -1,7 +1,7 @@
 import { PlatformAddress } from "codechain-primitives";
 import * as _ from "lodash";
 
-import { blake256, recoverEcdsa, ripemd160 } from "../utils";
+import { blake160, blake256, recoverEcdsa } from "../utils";
 
 import { H160 } from "./H160";
 import { H256 } from "./H256";
@@ -175,7 +175,7 @@ export class SignedParcel {
             s: s.value.toString(16),
             v
         });
-        return new H160(ripemd160(blake256(publicKey)));
+        return new H160(blake160(publicKey));
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import {
+    blake160 as _blake160,
     blake256 as _blake256,
     blake256WithKey as _blake256WithKey,
     generatePrivateKey as _generatePrivateKey,
@@ -25,6 +26,13 @@ export const toHex = (buffer: Buffer): string => _toHex(buffer);
  * @returns 32 byte hexadecimal string
  */
 export const blake256 = (data: Buffer | string): string => _blake256(data);
+
+/**
+ * Gets data's 160 bit blake hash.
+ * @param data buffer or hexadecimal string
+ * @returns 20 byte hexadecimal string
+ */
+export const blake160 = (data: Buffer | string): string => _blake160(data);
 
 /**
  * Gets data's 256 bit blake hash by using the key.


### PR DESCRIPTION
Currently, an account address is a
`ripemd160(blake2b(public_key, outlen=32))` The reason for using
ripemd160 was that it's the fasted way to generate 160 bits hash. But
blake2b can create 160 bits result. So this patch changes an account
address to `blake2b(public_key, outlen=20)`.