### PR TITLE
Fix the codechain-primitives version to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "buffer": "5.1.0",
     "codechain-keystore": "^0.5.4",
-    "codechain-primitives": "^0.3.3",
+    "codechain-primitives": "0.3.4",
     "jayson": "^2.0.6",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",


### PR DESCRIPTION
The 0.3.5 has a breaking change.
The travis have passed because yarn.lock file is cached.

```
$ tsc -p .
src/core/transaction/AssetMintOutput.ts:52:21 - error TS2322: Type 'Payload' is not assignable to type 'H160'.
  Type 'Multisig' is not assignable to type 'H160'.

52                     this.lockScriptHash = payload;
                       ~~~~~~~~~~~~~~~~~~~

src/core/transaction/AssetMintOutput.ts:57:60 - error TS2339: Property 'value' does not exist on type 'Payload'.
  Property 'value' does not exist on type 'Multisig'.

57                     this.parameters = [Buffer.from(payload.value, "hex")];
                                                              ~~~~~

src/core/transaction/AssetMintOutput.ts:61:60 - error TS2339: Property 'value' does not exist on type 'Payload'.
  Property 'value' does not exist on type 'Multisig'.

61                     this.parameters = [Buffer.from(payload.value, "hex")];
                                                              ~~~~~

src/core/transaction/AssetTransferOutput.ts:63:21 - error TS2322: Type 'Payload' is not assignable to type 'H160'.
  Type 'Multisig' is not assignable to type 'H160'.
    Property 'value' is missing in type 'Multisig'.

63                     this.lockScriptHash = payload;
                       ~~~~~~~~~~~~~~~~~~~

src/core/transaction/AssetTransferOutput.ts:68:60 - error TS2339: Property 'value' does not exist on type 'Payload'.
  Property 'value' does not exist on type 'Multisig'.

68                     this.parameters = [Buffer.from(payload.value, "hex")];
                                                              ~~~~~

src/core/transaction/AssetTransferOutput.ts:72:60 - error TS2339: Property 'value' does not exist on type 'Payload'.
  Property 'value' does not exist on type 'Multisig'.

72                     this.parameters = [Buffer.from(payload.value, "hex")];
                                                              ~~~~~

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```