### PR TITLE
Increase the maximum of the asset amount

### DIFF
--- a/src/core/Asset.ts
+++ b/src/core/Asset.ts
@@ -7,12 +7,13 @@ import { AssetTransferInput, Timelock } from "./transaction/AssetTransferInput";
 import { AssetTransferOutput } from "./transaction/AssetTransferOutput";
 import { AssetTransferTransaction } from "./transaction/AssetTransferTransaction";
 import { NetworkId } from "./types";
+import { U256 } from "./U256";
 
 export interface AssetData {
     assetType: H256;
     lockScriptHash: H160;
     parameters: Buffer[];
-    amount: number;
+    amount: U256;
     transactionHash: H256;
     transactionOutputIndex: number;
 }
@@ -36,7 +37,7 @@ export class Asset {
             parameters: parameters.map((p: Buffer | number[]) =>
                 Buffer.from(p)
             ),
-            amount,
+            amount: U256.ensure(amount),
             transactionHash: new H256(transactionHash),
             transactionOutputIndex
         });
@@ -45,7 +46,7 @@ export class Asset {
     public readonly assetType: H256;
     public readonly lockScriptHash: H160;
     public readonly parameters: Buffer[];
-    public readonly amount: number;
+    public readonly amount: U256;
     public readonly outPoint: AssetOutPoint;
 
     constructor(data: AssetData) {
@@ -84,7 +85,7 @@ export class Asset {
             asset_type: assetType.value,
             lock_script_hash: lockScriptHash.value,
             parameters,
-            amount,
+            amount: amount.toEncodeObject(),
             transactionHash: transactionHash.value,
             transactionOutputIndex: index
         };
@@ -103,7 +104,7 @@ export class Asset {
     public createTransferTransaction(params: {
         recipients?: Array<{
             address: AssetTransferAddress | string;
-            amount: number;
+            amount: U256;
         }>;
         timelock?: null | Timelock;
         networkId: NetworkId;

--- a/src/core/AssetScheme.ts
+++ b/src/core/AssetScheme.ts
@@ -7,6 +7,7 @@ import {
 import { AssetMintOutput } from "./transaction/AssetMintOutput";
 import { AssetMintTransaction } from "./transaction/AssetMintTransaction";
 import { NetworkId } from "./types";
+import { U256 } from "./U256";
 
 /**
  * Object that contains information about the Asset when performing AssetMintTransaction.
@@ -16,12 +17,12 @@ export class AssetScheme {
         const { metadata, amount, registrar, pool } = data;
         return new AssetScheme({
             metadata,
-            amount,
+            amount: U256.ensure(amount),
             registrar:
                 registrar === null ? null : PlatformAddress.ensure(registrar),
             pool: pool.map(({ assetType, amount: assetAmount }: any) => ({
                 assetType: H256.ensure(assetType),
-                amount: assetAmount
+                amount: U256.ensure(assetAmount)
             }))
         });
     }
@@ -29,17 +30,17 @@ export class AssetScheme {
     public readonly networkId?: NetworkId;
     public readonly shardId?: number;
     public readonly metadata: string;
-    public readonly amount: number;
+    public readonly amount: U256;
     public readonly registrar: PlatformAddress | null;
-    public readonly pool: { assetType: H256; amount: number }[];
+    public readonly pool: { assetType: H256; amount: U256 }[];
 
     constructor(data: {
         networkId?: NetworkId;
         shardId?: number;
         metadata: string;
-        amount: number;
+        amount: U256;
         registrar: PlatformAddress | null;
-        pool: { assetType: H256; amount: number }[];
+        pool: { assetType: H256; amount: U256 }[];
     }) {
         this.networkId = data.networkId;
         this.shardId = data.shardId;
@@ -53,11 +54,11 @@ export class AssetScheme {
         const { metadata, amount, registrar, pool } = this;
         return {
             metadata,
-            amount,
+            amount: amount.toEncodeObject(),
             registrar: registrar === null ? null : registrar.toString(),
             pool: pool.map(a => ({
                 assetType: a.assetType.value,
-                amount: a.amount
+                amount: a.amount.toEncodeObject()
             }))
         };
     }

--- a/src/core/__test__/Asset.spec.ts
+++ b/src/core/__test__/Asset.spec.ts
@@ -1,6 +1,7 @@
 import { Asset } from "../Asset";
 import { H160 } from "../H160";
 import { H256 } from "../H256";
+import { U256 } from "../U256";
 
 test("toJSON", () => {
     const asset = new Asset({
@@ -9,7 +10,7 @@ test("toJSON", () => {
         ),
         lockScriptHash: new H160("1111111111111111111111111111111111111111"),
         parameters: [],
-        amount: 222,
+        amount: new U256(222),
         transactionHash: new H256(
             "2222222222222222222222222222222222222222222222222222222222222222"
         ),

--- a/src/core/__test__/AssetScheme.spec.ts
+++ b/src/core/__test__/AssetScheme.spec.ts
@@ -1,9 +1,10 @@
 import { AssetScheme } from "../AssetScheme";
+import { U256 } from "../U256";
 
 test("toJSON", () => {
     const assetScheme = new AssetScheme({
         metadata: "abcd",
-        amount: 111,
+        amount: new U256(111),
         registrar: null,
         pool: []
     });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -184,7 +184,7 @@ export class Core {
     public createAssetScheme(params: {
         shardId: number;
         metadata: string;
-        amount: number;
+        amount: U256 | number | string;
         registrar?: PlatformAddress | string;
         pool?: { assetType: H256 | string; amount: number }[];
     }): AssetScheme {
@@ -197,18 +197,18 @@ export class Core {
         } = params;
         checkShardId(shardId);
         checkMetadata(metadata);
-        checkAmountU64(amount);
+        checkAmount(amount);
         checkRegistrar(registrar);
         return new AssetScheme({
             networkId: this.networkId,
             shardId,
             metadata,
-            amount,
+            amount: U256.ensure(amount),
             registrar:
                 registrar === null ? null : PlatformAddress.ensure(registrar),
             pool: pool.map(({ assetType, amount: assetAmount }) => ({
                 assetType: H256.ensure(assetType),
-                amount: assetAmount
+                amount: U256.ensure(assetAmount)
             }))
         });
     }
@@ -221,7 +221,7 @@ export class Core {
                   shardId: number;
                   metadata: string;
                   registrar?: PlatformAddress | string;
-                  amount: number | null;
+                  amount?: U256 | number | string | null;
               };
         recipient: AssetTransferAddress | string;
     }): AssetMintTransaction {
@@ -246,8 +246,8 @@ export class Core {
         checkShardId(shardId);
         checkMetadata(metadata);
         checkRegistrar(registrar);
-        if (amount !== null) {
-            checkAmountU64(amount);
+        if (amount != null) {
+            checkAmount(amount);
         }
         return new AssetMintTransaction({
             networkId,
@@ -256,7 +256,7 @@ export class Core {
                 registrar == null ? null : PlatformAddress.ensure(registrar),
             metadata,
             output: new AssetMintOutput({
-                amount,
+                amount: amount == null ? null : U256.ensure(amount),
                 recipient: AssetTransferAddress.ensure(recipient)
             })
         });
@@ -292,7 +292,7 @@ export class Core {
             | {
                   shardId: number;
                   metadata: string;
-                  amount: number | null;
+                  amount?: U256 | number | string | null;
                   registrar?: PlatformAddress | string;
                   networkId?: NetworkId;
               };
@@ -316,8 +316,8 @@ export class Core {
         checkShardId(shardId);
         checkMetadata(metadata);
         checkRegistrar(registrar);
-        if (amount !== null) {
-            checkAmountU64(amount);
+        if (amount != null) {
+            checkAmount(amount);
         }
         return new AssetComposeTransaction({
             networkId,
@@ -328,7 +328,7 @@ export class Core {
             inputs,
             output: new AssetMintOutput({
                 recipient: AssetTransferAddress.ensure(recipient),
-                amount
+                amount: amount == null ? null : U256.ensure(amount)
             })
         });
     }
@@ -365,7 +365,7 @@ export class Core {
                   transactionHash: H256 | string;
                   index: number;
                   assetType: H256 | string;
-                  amount: number;
+                  amount: U256 | number | string;
                   lockScriptHash?: H256 | string;
                   parameters?: Buffer[];
               };
@@ -395,7 +395,7 @@ export class Core {
         checkTransactionHash(transactionHash);
         checkIndex(index);
         checkAssetType(assetType);
-        checkAmountU64(amount);
+        checkAmount(amount);
         checkTimelock(timelock);
         if (lockScriptHash) {
             checkLockScriptHash(lockScriptHash);
@@ -417,7 +417,7 @@ export class Core {
                           transactionHash: H256.ensure(transactionHash),
                           index,
                           assetType: H256.ensure(assetType),
-                          amount,
+                          amount: U256.ensure(amount),
                           lockScriptHash: lockScriptHash
                               ? H160.ensure(lockScriptHash)
                               : undefined,
@@ -433,25 +433,25 @@ export class Core {
         transactionHash: H256 | string;
         index: number;
         assetType: H256 | string;
-        amount: number;
+        amount: U256 | number | string;
     }): AssetOutPoint {
         const { transactionHash, index, assetType, amount } = params;
         checkTransactionHash(transactionHash);
         checkIndex(index);
         checkAssetType(assetType);
-        checkAmountU64(amount);
+        checkAmount(amount);
         return new AssetOutPoint({
             transactionHash: H256.ensure(transactionHash),
             index,
             assetType: H256.ensure(assetType),
-            amount
+            amount: U256.ensure(amount)
         });
     }
 
     public createAssetTransferOutput(
         params: {
             assetType: H256 | string;
-            amount: number;
+            amount: U256 | number | string;
         } & (
             | {
                   recipient: AssetTransferAddress | string;
@@ -461,9 +461,10 @@ export class Core {
                   parameters: Buffer[];
               })
     ): AssetTransferOutput {
-        const { assetType, amount } = params;
+        const { assetType } = params;
+        const amount = U256.ensure(params.amount);
         checkAssetType(assetType);
-        checkAmountU64(amount);
+        checkAmount(amount);
         if ("recipient" in params) {
             const { recipient } = params;
             checkAssetTransferAddressRecipient(recipient);
@@ -524,13 +525,6 @@ function checkAmount(amount: U256 | number | string) {
         throw Error(
             `Expected amount param to be a U256 value but found ${amount}`
         );
-    }
-}
-
-// FIXME: U64
-function checkAmountU64(amount: number) {
-    if (typeof amount !== "number" || !Number.isInteger(amount) || amount < 0) {
-        throw Error(`Expected amount param to be a number but found ${amount}`);
     }
 }
 

--- a/src/core/transaction/AssetDecomposeTransaction.ts
+++ b/src/core/transaction/AssetDecomposeTransaction.ts
@@ -9,6 +9,7 @@ import * as _ from "lodash";
 
 import { Asset } from "../Asset";
 import { AssetTransferOutputValue, NetworkId } from "../types";
+import { U256 } from "../U256";
 import { AssetTransferInput } from "./AssetTransferInput";
 import { AssetTransferOutput } from "./AssetTransferOutput";
 
@@ -136,7 +137,7 @@ export class AssetDecomposeTransaction {
                 this.outputs.push(
                     new AssetTransferOutput({
                         recipient: AssetTransferAddress.ensure(recipient),
-                        amount,
+                        amount: U256.ensure(amount),
                         assetType: H256.ensure(assetType)
                     })
                 );

--- a/src/core/transaction/AssetMintOutput.ts
+++ b/src/core/transaction/AssetMintOutput.ts
@@ -3,6 +3,7 @@ import { AssetTransferAddress, H160 } from "codechain-primitives/lib";
 
 import { P2PKH } from "../../key/P2PKH";
 import { P2PKHBurn } from "../../key/P2PKHBurn";
+import { U256 } from "../U256";
 
 export class AssetMintOutput {
     /**
@@ -13,19 +14,19 @@ export class AssetMintOutput {
     public static fromJSON(data: {
         lockScriptHash: string;
         parameters: Buffer[];
-        amount: number | null;
+        amount?: string | null;
     }) {
         const { lockScriptHash, parameters, amount } = data;
         return new this({
             lockScriptHash: H160.ensure(lockScriptHash),
             parameters: parameters.map(p => Buffer.from(p)),
-            amount
+            amount: amount == null ? null : U256.ensure(amount)
         });
     }
 
     public readonly lockScriptHash: H160;
     public readonly parameters: Buffer[];
-    public readonly amount: number | null;
+    public readonly amount?: U256 | null;
 
     /**
      * @param data.lockScriptHash A lock script hash of the output.
@@ -37,11 +38,11 @@ export class AssetMintOutput {
             | {
                   lockScriptHash: H160;
                   parameters: Buffer[];
-                  amount: number | null;
+                  amount?: U256 | null;
               }
             | {
                   recipient: AssetTransferAddress;
-                  amount: number | null;
+                  amount?: U256 | null;
               }
     ) {
         if ("recipient" in data) {
@@ -86,7 +87,8 @@ export class AssetMintOutput {
         return {
             lockScriptHash: this.lockScriptHash.value,
             parameters: this.parameters.map(p => [...p]),
-            amount: this.amount
+            amount:
+                this.amount == null ? undefined : this.amount.toEncodeObject()
         };
     }
 }

--- a/src/core/transaction/AssetMintTransaction.ts
+++ b/src/core/transaction/AssetMintTransaction.ts
@@ -108,7 +108,7 @@ export class AssetMintTransaction {
             metadata,
             lockScriptHash.toEncodeObject(),
             parameters.map(parameter => Buffer.from(parameter)),
-            amount !== null ? [amount] : [],
+            amount != null ? [amount.toEncodeObject()] : [],
             registrar ? [registrar.getAccountId().toEncodeObject()] : []
         ];
     }
@@ -135,7 +135,7 @@ export class AssetMintTransaction {
     public getMintedAsset(): Asset {
         const { lockScriptHash, parameters, amount } = this.output;
         // FIXME: need U64 to be implemented or use U256
-        if (amount === null) {
+        if (amount == null) {
             throw Error("not implemented");
         }
         return new Asset({
@@ -161,7 +161,7 @@ export class AssetMintTransaction {
             registrar
         } = this;
         // FIXME: need U64 to be implemented or use U256
-        if (amount === null) {
+        if (amount == null) {
             throw Error("not implemented");
         }
         return new AssetScheme({

--- a/src/core/transaction/AssetOutPoint.ts
+++ b/src/core/transaction/AssetOutPoint.ts
@@ -1,11 +1,12 @@
 import { H160 } from "../H160";
 import { H256 } from "../H256";
+import { U256 } from "../U256";
 
 export interface AssetOutPointData {
     transactionHash: H256;
     index: number;
     assetType: H256;
-    amount: number;
+    amount: U256;
     lockScriptHash?: H160;
     parameters?: Buffer[];
 }
@@ -29,13 +30,13 @@ export class AssetOutPoint {
             transactionHash: new H256(transactionHash),
             index,
             assetType: new H256(assetType),
-            amount
+            amount: U256.ensure(amount)
         });
     }
     public readonly transactionHash: H256;
     public readonly index: number;
     public readonly assetType: H256;
-    public readonly amount: number;
+    public readonly amount: U256;
     public readonly lockScriptHash?: H160;
     public readonly parameters?: Buffer[];
 
@@ -73,7 +74,7 @@ export class AssetOutPoint {
             transactionHash.toEncodeObject(),
             index,
             assetType.toEncodeObject(),
-            amount
+            amount.toEncodeObject()
         ];
     }
 
@@ -87,7 +88,7 @@ export class AssetOutPoint {
             transactionHash: transactionHash.value,
             index,
             assetType: assetType.value,
-            amount
+            amount: amount.toEncodeObject()
         };
     }
 }

--- a/src/core/transaction/AssetTransferOutput.ts
+++ b/src/core/transaction/AssetTransferOutput.ts
@@ -5,18 +5,19 @@ import { P2PKH } from "../../key/P2PKH";
 import { P2PKHBurn } from "../../key/P2PKHBurn";
 
 import { H256 } from "../H256";
+import { U256 } from "../U256";
 
 export interface AssetTransferOutputData {
     lockScriptHash: H160;
     parameters: Buffer[];
     assetType: H256;
-    amount: number;
+    amount: U256;
 }
 
 export interface AssetTransferOutputAddressData {
     recipient: AssetTransferAddress;
     assetType: H256;
-    amount: number;
+    amount: U256;
 }
 
 /**
@@ -38,13 +39,13 @@ export class AssetTransferOutput {
                 Buffer.from(p)
             ),
             assetType: H256.ensure(assetType),
-            amount
+            amount: U256.ensure(amount)
         });
     }
     public readonly lockScriptHash: H160;
     public readonly parameters: Buffer[];
     public readonly assetType: H256;
-    public readonly amount: number;
+    public readonly amount: U256;
 
     /**
      * @param data.lockScriptHash A lock script hash of the output.
@@ -100,7 +101,7 @@ export class AssetTransferOutput {
             lockScriptHash.toEncodeObject(),
             parameters.map(parameter => Buffer.from(parameter)),
             assetType.toEncodeObject(),
-            amount
+            amount.toEncodeObject()
         ];
     }
 
@@ -114,7 +115,7 @@ export class AssetTransferOutput {
             lockScriptHash: lockScriptHash.value,
             parameters: parameters.map(parameter => [...parameter]),
             assetType: assetType.value,
-            amount
+            amount: amount.toEncodeObject()
         };
     }
 

--- a/src/core/transaction/AssetTransferTransaction.ts
+++ b/src/core/transaction/AssetTransferTransaction.ts
@@ -11,6 +11,7 @@ import {
 import { Asset } from "../Asset";
 import { H256 } from "../H256";
 import { AssetTransferOutputValue, NetworkId } from "../types";
+import { U256 } from "../U256";
 import { AssetTransferInput } from "./AssetTransferInput";
 import { AssetTransferOutput } from "./AssetTransferOutput";
 
@@ -181,7 +182,7 @@ export class AssetTransferTransaction {
                 this.outputs.push(
                     new AssetTransferOutput({
                         recipient: AssetTransferAddress.ensure(recipient),
-                        amount,
+                        amount: U256.ensure(amount),
                         assetType: H256.ensure(assetType)
                     })
                 );

--- a/src/core/transaction/__test__/AssetMintTransaction.spec.ts
+++ b/src/core/transaction/__test__/AssetMintTransaction.spec.ts
@@ -1,4 +1,5 @@
 import { H160 } from "../../H160";
+import { U256 } from "../../U256";
 import { AssetMintTransaction } from "../AssetMintTransaction";
 
 test("AssetMintTransaction toJSON", () => {
@@ -11,7 +12,7 @@ test("AssetMintTransaction toJSON", () => {
                 "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
             ),
             parameters: [],
-            amount: 0
+            amount: new U256(0)
         },
         registrar: null
     });

--- a/src/core/transaction/__test__/AssetTransferTransaction.spec.ts
+++ b/src/core/transaction/__test__/AssetTransferTransaction.spec.ts
@@ -1,5 +1,6 @@
 import { H160 } from "../../H160";
 import { H256 } from "../../H256";
+import { U256 } from "../../U256";
 import { AssetOutPoint } from "../AssetOutPoint";
 import { AssetTransferInput } from "../AssetTransferInput";
 import { AssetTransferOutput } from "../AssetTransferOutput";
@@ -24,7 +25,7 @@ test("AssetOutPoint toJSON", () => {
         assetType: new H256(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         ),
-        amount: 1
+        amount: new U256(1)
     });
     expect(AssetOutPoint.fromJSON(outPoint.toJSON())).toEqual(outPoint);
 });
@@ -38,7 +39,7 @@ test("AssetTransferInput toJSON", () => {
         assetType: new H256(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         ),
-        amount: 1
+        amount: new U256(1)
     });
     const input = new AssetTransferInput({
         prevOut: outPoint,
@@ -56,7 +57,7 @@ test("AssetTransferOutput toJSON", () => {
         assetType: new H256(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         ),
-        amount: 321
+        amount: new U256(321)
     });
     expect(AssetTransferOutput.fromJSON(output.toJSON())).toEqual(output);
 });
@@ -68,7 +69,7 @@ test("AssetTransferOutput shard id", () => {
         assetType: new H256(
             "4100BAADCAFEBEEFbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         ),
-        amount: 321
+        amount: new U256(321)
     });
     expect(output.shardId()).toEqual(parseInt("BAAD", 16));
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,12 +1,13 @@
 import { AssetTransferAddress, H256 } from "codechain-primitives/lib";
 import { AssetTransferOutput } from "./transaction/AssetTransferOutput";
+import { U256 } from "./U256";
 
 export type NetworkId = string;
 
 export type AssetTransferOutputValue =
     | AssetTransferOutput
     | {
-          amount: number;
+          amount: U256 | number | string;
           assetType: H256 | string;
           recipient: AssetTransferAddress | string;
       };


### PR DESCRIPTION
Since we has a plan to support wrapped CCC, the asset amount must be able to cover the amount of the CCC.
So this patch changes the type of asset amount to U256.