### PR TITLE
Add & Fix RPC functions on account/engine/devel

### DIFF
--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -715,5 +715,45 @@ describe("rpc", () => {
                     });
             });
         });
+
+        describe("changePassword", () => {
+            let address: string;
+            beforeEach(async () => {
+                address = await sdk.rpc.account.create("123");
+            });
+
+            test("Ok", async () => {
+                await sdk.rpc.account.changePassword(address, "123", "456");
+                await sdk.rpc.account.changePassword(address, "456", "");
+                await sdk.rpc.account.changePassword(address, "", "123");
+
+                const addressWithNoPassphrase = await sdk.rpc.account.create();
+                await sdk.rpc.account.changePassword(
+                    addressWithNoPassphrase,
+                    "",
+                    "123"
+                );
+            });
+
+            test("WrongPassword", async done => {
+                sdk.rpc.account
+                    .changePassword(address, "456", "123")
+                    .then(() => done.fail())
+                    .catch(e => {
+                        expect(e).toEqual(ERROR.WRONG_PASSWORD);
+                        done();
+                    });
+            });
+
+            test("NoSuchAccount", async done => {
+                sdk.rpc.account
+                    .changePassword(noSuchAccount, "123", "456")
+                    .then(() => done.fail())
+                    .catch(e => {
+                        expect(e).toEqual(ERROR.NO_SUCH_ACCOUNT);
+                        done();
+                    });
+            });
+        });
     });
 });

--- a/src/rpc/account.ts
+++ b/src/rpc/account.ts
@@ -262,4 +262,46 @@ export class AccountRpc {
                 .catch(reject);
         });
     }
+
+    /**
+     * Changes the passpharse of the account
+     * @param address A platform address
+     * @param oldPassphrase The account's current passphrase
+     * @param newPassphrase The new passphrase for the account
+     */
+    public changePassword(
+        address: PlatformAddress | string,
+        oldPassphrase: string,
+        newPassphrase: string
+    ): Promise<null> {
+        if (oldPassphrase && typeof oldPassphrase !== "string") {
+            throw Error(
+                `Expected the second argument to be a string but given ${oldPassphrase}`
+            );
+        }
+        if (newPassphrase && typeof newPassphrase !== "string") {
+            throw Error(
+                `Expected the second argument to be a string but given ${newPassphrase}`
+            );
+        }
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("account_changePassword", [
+                    address,
+                    oldPassphrase,
+                    newPassphrase
+                ])
+                .then(result => {
+                    if (result === null) {
+                        return resolve(null);
+                    }
+                    reject(
+                        Error(
+                            `Expected account_changePassword to return null but it returned ${result}`
+                        )
+                    );
+                })
+                .catch(reject);
+        });
+    }
 }

--- a/src/rpc/devel.ts
+++ b/src/rpc/devel.ts
@@ -1,3 +1,5 @@
+import { H256 } from "codechain-primitives";
+
 import { Rpc } from ".";
 
 export class DevelRpc {
@@ -8,6 +10,98 @@ export class DevelRpc {
      */
     constructor(rpc: Rpc) {
         this.rpc = rpc;
+    }
+
+    /**
+     * Gets keys of the state trie with the given offset and limit.
+     * @param offset number
+     * @param limit number
+     * @returns H256[]
+     */
+    public getStateTrieKeys(offset: number, limit: number): Promise<H256[]> {
+        if (
+            typeof offset !== "number" ||
+            !Number.isInteger(offset) ||
+            offset < 0
+        ) {
+            throw Error(
+                `Expected the first argument to be non-negative integer but found ${offset}`
+            );
+        }
+        if (
+            typeof limit !== "number" ||
+            !Number.isInteger(limit) ||
+            limit <= 0
+        ) {
+            throw Error(
+                `Expected the second argument to be posivit integer but found ${limit}`
+            );
+        }
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("devel_getStateTrieKeys", [offset, limit])
+                .then(result => {
+                    if (!Array.isArray(result)) {
+                        return reject(
+                            Error(
+                                `Expected devel_getStateTrieKeys to return an array but it returned ${result}`
+                            )
+                        );
+                    }
+                    result.forEach((value, index, arr) => {
+                        try {
+                            arr[index] = new H256(value);
+                        } catch (e) {
+                            return reject(
+                                Error(
+                                    `Expected devel_getStateTrieKeys() to return an array of H256, but an error occurred: ${e.toString()}`
+                                )
+                            );
+                        }
+                    });
+                    resolve(result);
+                })
+                .catch(reject);
+        });
+    }
+
+    /**
+     * Gets the value of the state trie with the given key.
+     * @param key H256
+     * @returns string[]
+     */
+    public getStateTrieValue(key: H256): Promise<string[]> {
+        if (!H256.check(key)) {
+            throw Error(
+                `Expected the first argument to be an H256 value but found ${key}`
+            );
+        }
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("devel_getStateTrieValue", [
+                    `0x${H256.ensure(key).value}`
+                ])
+                .then(result => {
+                    if (!Array.isArray(result)) {
+                        return reject(
+                            Error(
+                                `Expected devel_getStateTrieValue to return an array but it returned ${result}`
+                            )
+                        );
+                    }
+                    result.forEach((value, index) => {
+                        if (typeof value !== "string") {
+                            return reject(
+                                Error(
+                                    `Expected devel_getStateTrieValue to return an array of strings but found ${value} at ${index}`
+                                )
+                            );
+                        }
+                    });
+                    resolve(result);
+                })
+                .catch(reject);
+        });
     }
 
     /**

--- a/src/rpc/engine.ts
+++ b/src/rpc/engine.ts
@@ -1,0 +1,86 @@
+import { PlatformAddress, U64 } from "codechain-primitives";
+
+import { Rpc } from ".";
+
+export class EngineRpc {
+    private rpc: Rpc;
+
+    /**
+     * @hidden
+     */
+    constructor(rpc: Rpc) {
+        this.rpc = rpc;
+    }
+
+    /**
+     * Gets coinbase's account id.
+     * @returns PlatformAddress or null
+     */
+    public getCoinbase(): Promise<PlatformAddress | null> {
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("engine_getCoinbase", [])
+                .then(result => {
+                    try {
+                        resolve(
+                            result === null
+                                ? null
+                                : PlatformAddress.fromString(result)
+                        );
+                    } catch (e) {
+                        reject(
+                            Error(
+                                `Expected engine_getCoinbase to return a PlatformAddress string or null, but an error occurred: ${e.toString()}`
+                            )
+                        );
+                    }
+                })
+                .catch(reject);
+        });
+    }
+
+    /**
+     * Gets coinbase's account id.
+     * @returns PlatformAddress or null
+     */
+    public getBlockReward(): Promise<U64> {
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("engine_getBlockReward", [])
+                .then(result => {
+                    try {
+                        resolve(U64.ensure(result));
+                    } catch (e) {
+                        reject(
+                            Error(
+                                `Expected engine_getBlockReward to return a U64, but an error occurred: ${e.toString()}`
+                            )
+                        );
+                    }
+                })
+                .catch(reject);
+        });
+    }
+
+    /**
+     * Gets coinbase's account id.
+     * @returns PlatformAddress or null
+     */
+    public getRecommendedConfirmation(): Promise<number> {
+        return new Promise((resolve, reject) => {
+            this.rpc
+                .sendRpcRequest("engine_getRecommendedConfirmation", [])
+                .then(result => {
+                    if (typeof result === "number") {
+                        return resolve(result);
+                    }
+                    reject(
+                        Error(
+                            `Expected engine_getRecommendedConfirmation to return a number but it returned ${result}`
+                        )
+                    );
+                })
+                .catch(reject);
+        });
+    }
+}

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import { AccountRpc } from "./account";
 import { ChainRpc } from "./chain";
 import { DevelRpc } from "./devel";
+import { EngineRpc } from "./engine";
 import { NetworkRpc } from "./network";
 import { NodeRpc } from "./node";
 
@@ -29,6 +30,13 @@ export class Rpc {
      */
     public account: AccountRpc;
 
+    /**
+     * RPC module for retrieving the engine info.
+     */
+    public engine: EngineRpc;
+    /**
+     * RPC module for developer functions
+     */
     public devel: DevelRpc;
     private client: any;
 
@@ -68,6 +76,7 @@ export class Rpc {
         this.chain = new ChainRpc(this, options);
         this.network = new NetworkRpc(this);
         this.account = new AccountRpc(this, options);
+        this.engine = new EngineRpc(this);
         this.devel = new DevelRpc(this);
     }
 

--- a/src/rpc/network.ts
+++ b/src/rpc/network.ts
@@ -417,16 +417,19 @@ export class NetworkRpc {
      */
     public disableBlacklist(): Promise<null> {
         return new Promise((resolve, reject) => {
-            this.rpc.sendRpcRequest("net_disableBlacklist", []).then(result => {
-                if (result === null) {
-                    return resolve(null);
-                }
-                reject(
-                    Error(
-                        `Expected net_disableBlacklist to return null but it returned ${result}`
-                    )
-                );
-            });
+            this.rpc
+                .sendRpcRequest("net_disableBlacklist", [])
+                .then(result => {
+                    if (result === null) {
+                        return resolve(null);
+                    }
+                    reject(
+                        Error(
+                            `Expected net_disableBlacklist to return null but it returned ${result}`
+                        )
+                    );
+                })
+                .catch(reject);
         });
     }
 


### PR DESCRIPTION
The functions which exist but not added to the SDK:
 * [x] account_changePassword
 * [x] engine_getCoinbase
 * [x] engine_getBlockReward
 * [x] engine_getRecommendedConfimation
 * [x] devel_getStateTrieKeys
 * [x] devel_getStateTrieValue

Others are moved to the issue #283.