### PR TITLE
Fix toJSON methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "buffer": "5.1.0",
     "codechain-keystore": "^0.6.0",
-    "codechain-primitives": "^0.4.3",
+    "codechain-primitives": "^0.4.4",
     "jayson": "^2.0.6",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",

--- a/src/core/Asset.ts
+++ b/src/core/Asset.ts
@@ -100,12 +100,12 @@ export class Asset {
         } = this;
         const { transactionHash, index } = outPoint;
         return {
-            assetType: assetType.value,
-            lockScriptHash: lockScriptHash.value,
+            assetType: assetType.toJSON(),
+            lockScriptHash: lockScriptHash.toJSON(),
             parameters: parameters.map(p => [...p]),
-            amount: `0x${amount.toString(16)}`,
-            orderHash: orderHash === null ? null : orderHash.toString(),
-            transactionHash: transactionHash.value,
+            amount: amount.toJSON(),
+            orderHash: orderHash === null ? null : orderHash.toJSON(),
+            transactionHash: transactionHash.toJSON(),
             transactionOutputIndex: index
         };
     }

--- a/src/core/AssetScheme.ts
+++ b/src/core/AssetScheme.ts
@@ -72,13 +72,13 @@ export class AssetScheme {
         const { metadata, amount, approver, administrator, pool } = this;
         return {
             metadata,
-            amount: `0x${amount.toString(16)}`,
+            amount: amount.toJSON(),
             approver: approver === null ? null : approver.toString(),
             administrator:
                 administrator === null ? null : administrator.toString(),
             pool: pool.map(a => ({
-                assetType: a.assetType.value,
-                amount: `0x${a.amount.toString(16)}`
+                assetType: a.assetType.toJSON(),
+                amount: a.amount.toJSON()
             }))
         };
     }

--- a/src/core/Block.ts
+++ b/src/core/Block.ts
@@ -113,17 +113,17 @@ export class Block {
             parcels
         } = this;
         return {
-            parentHash: parentHash.value,
+            parentHash: parentHash.toJSON(),
             timestamp,
             number,
             author: author.toString(),
             extraData,
-            parcelsRoot: parcelsRoot.value,
-            stateRoot: stateRoot.value,
-            invoicesRoot: invoicesRoot.value,
+            parcelsRoot: parcelsRoot.toJSON(),
+            stateRoot: stateRoot.toJSON(),
+            invoicesRoot: invoicesRoot.toJSON(),
             score: score.value.toString(),
             seal,
-            hash: hash.value,
+            hash: hash.toJSON(),
             parcels: parcels.map(p => p.toJSON())
         };
     }

--- a/src/core/Parcel.ts
+++ b/src/core/Parcel.ts
@@ -127,7 +127,7 @@ export class Parcel {
             throw Error("Fee in the parcel must be present");
         }
         const result: any = {
-            fee: fee.toEncodeObject(),
+            fee: fee.toJSON(),
             networkId,
             action: action.toJSON()
         };

--- a/src/core/SignedParcel.ts
+++ b/src/core/SignedParcel.ts
@@ -232,14 +232,14 @@ export class SignedParcel {
         }
         return {
             blockNumber,
-            blockHash: blockHash === null ? null : blockHash.value,
+            blockHash: blockHash === null ? null : blockHash.toJSON(),
             parcelIndex,
             seq,
-            fee: fee.value.toString(),
+            fee: fee.toJSON(),
             networkId,
             action: action.toJSON(),
             sig,
-            hash: this.hash().value
+            hash: this.hash().toJSON()
         };
     }
 }

--- a/src/core/action/SetRegularKey.ts
+++ b/src/core/action/SetRegularKey.ts
@@ -14,7 +14,7 @@ export class SetRegularKey {
     public toJSON() {
         return {
             action: "setRegularKey",
-            key: this.key.value
+            key: this.key.toJSON()
         };
     }
 }

--- a/src/core/action/WrapCCC.ts
+++ b/src/core/action/WrapCCC.ts
@@ -106,9 +106,9 @@ export class WrapCCC {
         return {
             action: "wrapCCC",
             shardId,
-            lockScriptHash: lockScriptHash.value,
+            lockScriptHash: lockScriptHash.toJSON(),
             parameters: parameters.map(parameter => [...parameter]),
-            amount: amount.toEncodeObject()
+            amount: amount.toJSON()
         };
     }
 }

--- a/src/core/transaction/AssetMintOutput.ts
+++ b/src/core/transaction/AssetMintOutput.ts
@@ -87,12 +87,9 @@ export class AssetMintOutput {
      */
     public toJSON(): AssetMintOutputJSON {
         return {
-            lockScriptHash: this.lockScriptHash.value,
+            lockScriptHash: this.lockScriptHash.toJSON(),
             parameters: this.parameters.map(p => [...p]),
-            amount:
-                this.amount == null
-                    ? undefined
-                    : `0x${this.amount.toString(16)}`
+            amount: this.amount == null ? undefined : this.amount.toJSON()
         };
     }
 }

--- a/src/core/transaction/AssetOutPoint.ts
+++ b/src/core/transaction/AssetOutPoint.ts
@@ -92,10 +92,10 @@ export class AssetOutPoint {
     public toJSON(): AssetOutPointJSON {
         const { transactionHash, index, assetType, amount } = this;
         return {
-            transactionHash: transactionHash.value,
+            transactionHash: transactionHash.toJSON(),
             index,
-            assetType: assetType.value,
-            amount: `0x${amount.toString(16)}`
+            assetType: assetType.toJSON(),
+            amount: amount.toJSON()
         };
     }
 }

--- a/src/core/transaction/AssetTransferOutput.ts
+++ b/src/core/transaction/AssetTransferOutput.ts
@@ -119,10 +119,10 @@ export class AssetTransferOutput {
     public toJSON(): AssetTransferOutputJSON {
         const { lockScriptHash, parameters, assetType, amount } = this;
         return {
-            lockScriptHash: lockScriptHash.value,
+            lockScriptHash: lockScriptHash.toJSON(),
             parameters: parameters.map(parameter => [...parameter]),
-            assetType: assetType.value,
-            amount: `0x${amount.toString(16)}`
+            assetType: assetType.toJSON(),
+            amount: amount.toJSON()
         };
     }
 

--- a/src/core/transaction/Order.ts
+++ b/src/core/transaction/Order.ts
@@ -250,15 +250,15 @@ export class Order {
             parameters
         } = this;
         return {
-            assetTypeFrom: assetTypeFrom.value,
-            assetTypeTo: assetTypeTo.value,
-            assetTypeFee: assetTypeFee.value,
-            assetAmountFrom: `0x${assetAmountFrom.toString(16)}`,
-            assetAmountTo: `0x${assetAmountTo.toString(16)}`,
-            assetAmountFee: `0x${assetAmountFee.toString(16)}`,
+            assetTypeFrom: assetTypeFrom.toJSON(),
+            assetTypeTo: assetTypeTo.toJSON(),
+            assetTypeFee: assetTypeFee.toJSON(),
+            assetAmountFrom: assetAmountFrom.toJSON(),
+            assetAmountTo: assetAmountTo.toJSON(),
+            assetAmountFee: assetAmountFee.toJSON(),
             originOutputs: originOutputs.map(output => output.toJSON()),
             expiration: expiration.toString(),
-            lockScriptHash: lockScriptHash.toEncodeObject(),
+            lockScriptHash: lockScriptHash.toJSON(),
             parameters: parameters.map(parameter => [...parameter])
         };
     }

--- a/src/core/transaction/OrderOnTransfer.ts
+++ b/src/core/transaction/OrderOnTransfer.ts
@@ -81,7 +81,7 @@ export class OrderOnTransfer {
         const { order, spentAmount, inputIndices, outputIndices } = this;
         return {
             order: order.toJSON(),
-            spentAmount: spentAmount.toString(),
+            spentAmount: spentAmount.toJSON(),
             inputIndices,
             outputIndices
         };


### PR DESCRIPTION
1. Use `toEncodeObject()` method on `Hxxx` types
2. Use `0x${~~~.toString(16)` on `Uint` fields in CodeChain

Need to check on CodeChain.
`toJSON()` is not used often in JSON-RPC, because types are usually converted into the RLP form.
To check, need to use RPC calls like `account_sendParcel` and `chain_executeTransaction`.