### PR TITLE
Change to check null explicitly on the toJSON of the signedParcel

### DIFF
--- a/src/core/SignedParcel.ts
+++ b/src/core/SignedParcel.ts
@@ -227,7 +227,7 @@ export class SignedParcel {
             s: s.value.toString(16),
             v
         });
-        if (!seq || !fee) {
+        if (seq == null || !fee) {
             throw Error("Seq and fee in the parcel must be present");
         }
         return {


### PR DESCRIPTION
If the seq is 0, an error occurs.