### PR TITLE
Rename transactionId to tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ node_js:
 before_install:
   - yarn install
 before_script:
-  - docker pull kodebox/codechain:d669b841f36ada2ec509f62a35147243e00f1bdc
-  - docker run -d -p 8080:8080 kodebox/codechain:d669b841f36ada2ec509f62a35147243e00f1bdc --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
+  - docker pull kodebox/codechain:672c4b5fa7824dbb90d9112355987058f169e421
+  - docker run -d -p 8080:8080 kodebox/codechain:672c4b5fa7824dbb90d9112355987058f169e421 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
   - docker ps -a
 script:
   - yarn test --verbose

--- a/examples/mint-and-burn.js
+++ b/examples/mint-and-burn.js
@@ -45,9 +45,12 @@ const ACCOUNT_PASSPHRASE = "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 300 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 300 * 1000
+        }
+    );
     if (!mintTxInvoices[0].success) {
         throw Error(
             `AssetMintTransaction failed: ${JSON.stringify(
@@ -55,8 +58,8 @@ const ACCOUNT_PASSPHRASE = "satoshi";
             )}`
         );
     }
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        transferTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        transferTx.tracker(),
         {
             timeout: 300 * 1000
         }

--- a/examples/mint-and-change-scheme.js
+++ b/examples/mint-and-change-scheme.js
@@ -37,9 +37,12 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 300 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 300 * 1000
+        }
+    );
     if (!mintTxInvoices[0].success) {
         throw Error(
             `AssetMintTransaction failed: ${JSON.stringify(
@@ -66,8 +69,8 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const assetSchemeChangeTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        assetSchemeChangeTx.id(),
+    const assetSchemeChangeTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        assetSchemeChangeTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -80,7 +83,9 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         );
     }
 
-    console.log(await sdk.rpc.chain.getAssetSchemeByHash(mintTx.id(), 0));
+    console.log(
+        await sdk.rpc.chain.getAssetSchemeByTracker(mintTx.tracker(), 0)
+    );
     console.log(
         await sdk.rpc.chain.getAssetSchemeByType(
             mintTx.getMintedAsset().assetType

--- a/examples/mint-and-compose-and-decompose.js
+++ b/examples/mint-and-compose-and-decompose.js
@@ -64,14 +64,17 @@ const ACCOUNT_PASSPHRASE = "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 300 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 300 * 1000
+        }
+    );
     if (!mintTxInvoices[0].success) {
         throw Error("AssetMintTransaction failed");
     }
-    const composeTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        composeTx.id(),
+    const composeTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        composeTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -79,8 +82,8 @@ const ACCOUNT_PASSPHRASE = "satoshi";
     if (!composeTxInvoices[0].success) {
         throw Error("AssetComposeTransaction failed");
     }
-    const decomposeTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        decomposeTx.id(),
+    const decomposeTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        decomposeTx.tracker(),
         {
             timeout: 300 * 1000
         }

--- a/examples/mint-and-compose.js
+++ b/examples/mint-and-compose.js
@@ -49,14 +49,17 @@ const ACCOUNT_PASSPHRASE = "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 300 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 300 * 1000
+        }
+    );
     if (!mintTxInvoices[0].success) {
         throw Error("AssetMintTransaction failed");
     }
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        composeTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        composeTx.tracker(),
         {
             timeout: 300 * 1000
         }

--- a/examples/mint-and-transfer-with-order.js
+++ b/examples/mint-and-transfer-with-order.js
@@ -110,8 +110,8 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const goldMintTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        goldMintTx.id(),
+    const goldMintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        goldMintTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -123,8 +123,8 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
             )}`
         );
     }
-    const silverMintTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        silverMintTx.id(),
+    const silverMintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        silverMintTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -136,8 +136,8 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
             )}`
         );
     }
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        transferTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        transferTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -151,13 +151,13 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
     }
 
     // Unspent Alice's 9900 golds with the order
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 0));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 0));
     // 1000 silvers from Bob to Alice by the order
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 1));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 1));
     // 100 golds from Alice to Bob, without any order (Bob owns)
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 2));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 2));
     // Unspent Bob's 99000 silvers without any order
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 3));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 3));
 })().catch(err => {
     console.error(`Error:`, err);
 });

--- a/examples/mint-and-transfer.js
+++ b/examples/mint-and-transfer.js
@@ -58,9 +58,12 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         passphrase: ACCOUNT_PASSPHRASE
     });
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 300 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 300 * 1000
+        }
+    );
     if (!mintTxInvoices[0].success) {
         throw Error(
             `AssetMintTransaction failed: ${JSON.stringify(
@@ -68,8 +71,8 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
             )}`
         );
     }
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        transferTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        transferTx.tracker(),
         {
             timeout: 300 * 1000
         }
@@ -83,9 +86,9 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
     }
 
     // Unspent Bob's 3000 golds
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 0));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 0));
     // Unspent Alice's 7000 golds
-    console.log(await sdk.rpc.chain.getAsset(transferTx.id(), 1));
+    console.log(await sdk.rpc.chain.getAsset(transferTx.tracker(), 1));
 })().catch(err => {
     console.error(`Error:`, err);
 });

--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -394,17 +394,19 @@ describe("rpc", () => {
                 );
             });
 
-            test("integration_tests/Rpc.spec.tsgetTransactionById", async () => {
+            test("getTransactionByTracker", async () => {
                 expect(
-                    ((await sdk.rpc.chain.getTransactionById(
-                        mintTransaction.id()
+                    ((await sdk.rpc.chain.getTransactionByTracker(
+                        mintTransaction.tracker()
                     )) as any).unsigned.actionToJSON()
                 ).toEqual((mintTransaction as any).actionToJSON());
             });
 
-            test("getInvoicesById", async () => {
+            test("getInvoicesByTracker", async () => {
                 expect(
-                    await sdk.rpc.chain.getInvoicesById(mintTransaction.id())
+                    await sdk.rpc.chain.getInvoicesByTracker(
+                        mintTransaction.tracker()
+                    )
                 ).toEqual(
                     expect.arrayContaining([
                         Invoice.fromJSON({ success: true })
@@ -412,15 +414,15 @@ describe("rpc", () => {
                 );
             });
 
-            test("getAssetScheme", async () => {
+            test("getAssetSchemeByTracker", async () => {
                 expect(
-                    await sdk.rpc.chain.getAssetSchemeByHash(
-                        mintTransaction.id(),
+                    await sdk.rpc.chain.getAssetSchemeByTracker(
+                        mintTransaction.tracker(),
                         shardId
                     )
                 ).toEqual(expect.any(AssetScheme));
                 expect(
-                    await sdk.rpc.chain.getAssetSchemeByHash(
+                    await sdk.rpc.chain.getAssetSchemeByTracker(
                         invalidHash,
                         shardId
                     )
@@ -429,10 +431,10 @@ describe("rpc", () => {
 
             test("getAsset", async () => {
                 expect(
-                    await sdk.rpc.chain.getAsset(mintTransaction.id(), 0)
+                    await sdk.rpc.chain.getAsset(mintTransaction.tracker(), 0)
                 ).toEqual(expect.any(Asset));
                 expect(
-                    await sdk.rpc.chain.getAsset(mintTransaction.id(), 1)
+                    await sdk.rpc.chain.getAsset(mintTransaction.tracker(), 1)
                 ).toBe(null);
                 expect(await sdk.rpc.chain.getAsset(invalidHash, 0)).toBe(null);
             });
@@ -440,14 +442,14 @@ describe("rpc", () => {
             test("isAssetSpent", async () => {
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         0,
                         shardId
                     )
                 ).toBe(false);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         1,
                         shardId
                     )
@@ -507,14 +509,14 @@ describe("rpc", () => {
             test("isAssetSpent", async () => {
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         0,
                         shardId
                     )
                 ).toBe(true);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         0,
                         shardId,
                         blockNumber - 2
@@ -522,7 +524,7 @@ describe("rpc", () => {
                 ).toBe(null);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         0,
                         shardId,
                         blockNumber
@@ -530,7 +532,7 @@ describe("rpc", () => {
                 ).toBe(true);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        mintTransaction.id(),
+                        mintTransaction.tracker(),
                         0,
                         wrongShardId
                     )
@@ -538,14 +540,14 @@ describe("rpc", () => {
 
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        transferTransaction.id(),
+                        transferTransaction.tracker(),
                         0,
                         shardId
                     )
                 ).toBe(false);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        transferTransaction.id(),
+                        transferTransaction.tracker(),
                         0,
                         shardId,
                         blockNumber - 2
@@ -553,7 +555,7 @@ describe("rpc", () => {
                 ).toBe(null);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        transferTransaction.id(),
+                        transferTransaction.tracker(),
                         0,
                         shardId,
                         blockNumber
@@ -561,7 +563,7 @@ describe("rpc", () => {
                 ).toBe(false);
                 expect(
                     await sdk.rpc.chain.isAssetSpent(
-                        transferTransaction.id(),
+                        transferTransaction.tracker(),
                         0,
                         wrongShardId
                     )

--- a/integration_tests/Transaction.spec.ts
+++ b/integration_tests/Transaction.spec.ts
@@ -58,7 +58,7 @@ test("AssetTransferTransaction fromJSONToTransaction", async () => {
         })
         .createMintTransaction({ recipient: addressA });
     await sendTransaction({ transaction: mintTx });
-    const firstAsset = await sdk.rpc.chain.getAsset(mintTx.id(), 0);
+    const firstAsset = await sdk.rpc.chain.getAsset(mintTx.tracker(), 0);
     if (firstAsset == null) {
         throw Error("Cannot get the first asset");
     }
@@ -80,7 +80,7 @@ test("AssetTransferTransaction fromJSONToTransaction", async () => {
     // FIXME: Remove anythings when *Data fields are flattened
     const expectedInput = expect.objectContaining({
         prevOut: expect.objectContaining({
-            transactionId: expect.any(H256),
+            tracker: expect.any(H256),
             index: expect.anything(),
             assetType: expect.any(H256),
             amount: expect.anything()

--- a/integration_tests/useApprover.spec.ts
+++ b/integration_tests/useApprover.spec.ts
@@ -104,9 +104,12 @@ async function mintAssetUsingMaster(
         })
     );
 
-    const mintTxInvoices = await sdk.rpc.chain.getInvoicesById(mintTx.id(), {
-        timeout: 5 * 60 * 1000
-    });
+    const mintTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        mintTx.tracker(),
+        {
+            timeout: 5 * 60 * 1000
+        }
+    );
     expect(mintTxInvoices.length).toBe(1);
     expect(mintTxInvoices[0].success).toBe(true);
     return mintTx;
@@ -144,8 +147,8 @@ async function transferAssetUsingRegular(
         })
     );
 
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        transferTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        transferTx.tracker(),
         {
             timeout: 5 * 60 * 1000
         }
@@ -190,8 +193,8 @@ async function transferAssetUsingOther(
         })
     );
 
-    const transferTxInvoices = await sdk.rpc.chain.getInvoicesById(
-        transferTx.id(),
+    const transferTxInvoices = await sdk.rpc.chain.getInvoicesByTracker(
+        transferTx.tracker(),
         {
             timeout: 5 * 60 * 1000
         }

--- a/src/core/Asset.ts
+++ b/src/core/Asset.ts
@@ -17,7 +17,7 @@ export interface AssetJSON {
     orderHash: string | null;
     // The `hash` and the `index` are not included in an RPC response. See
     // getAsset() in chain.ts for more details.
-    transactionId: string;
+    tracker: string;
     transactionOutputIndex: number;
 }
 
@@ -27,7 +27,7 @@ export interface AssetData {
     parameters: Buffer[];
     amount: U64;
     orderHash?: H256 | null;
-    transactionId: H256;
+    tracker: H256;
     transactionOutputIndex: number;
 }
 /**
@@ -41,7 +41,7 @@ export class Asset {
             parameters,
             amount,
             orderHash,
-            transactionId,
+            tracker,
             transactionOutputIndex
         } = data;
         return new Asset({
@@ -52,7 +52,7 @@ export class Asset {
             ),
             amount: U64.ensure(amount),
             orderHash: orderHash === null ? orderHash : H256.ensure(orderHash),
-            transactionId: new H256(transactionId),
+            tracker: new H256(tracker),
             transactionOutputIndex
         });
     }
@@ -66,7 +66,7 @@ export class Asset {
 
     constructor(data: AssetData) {
         const {
-            transactionId,
+            tracker,
             transactionOutputIndex,
             assetType,
             amount,
@@ -80,7 +80,7 @@ export class Asset {
         this.amount = data.amount;
         this.orderHash = orderHash;
         this.outPoint = new AssetOutPoint({
-            transactionId,
+            tracker,
             index: transactionOutputIndex,
             assetType,
             amount,
@@ -98,14 +98,14 @@ export class Asset {
             amount,
             outPoint
         } = this;
-        const { transactionId, index } = outPoint;
+        const { tracker, index } = outPoint;
         return {
             assetType: assetType.toJSON(),
             lockScriptHash: lockScriptHash.toJSON(),
             parameters: parameters.map(p => [...p]),
             amount: amount.toJSON(),
             orderHash: orderHash === null ? null : orderHash.toJSON(),
-            transactionId: transactionId.toJSON(),
+            tracker: tracker.toJSON(),
             transactionOutputIndex: index
         };
     }

--- a/src/core/Transaction.ts
+++ b/src/core/Transaction.ts
@@ -7,7 +7,7 @@ import { U64 } from "./U64";
 const RLP = require("rlp");
 
 export interface AssetTransaction {
-    id(): H256;
+    tracker(): H256;
 }
 
 /**

--- a/src/core/__test__/Asset.spec.ts
+++ b/src/core/__test__/Asset.spec.ts
@@ -11,7 +11,7 @@ test("toJSON", () => {
         lockScriptHash: new H160("1111111111111111111111111111111111111111"),
         parameters: [],
         amount: new U64(222),
-        transactionId: new H256(
+        tracker: new H256(
             "2222222222222222222222222222222222222222222222222222222222222222"
         ),
         transactionOutputIndex: 0

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -376,7 +376,7 @@ export class Core {
             originOutputs:
                 | AssetOutPoint[]
                 | {
-                      transactionId: H256 | string;
+                      tracker: H256 | string;
                       index: number;
                       assetType: H256 | string;
                       amount: U64 | number | string;
@@ -423,7 +423,7 @@ export class Core {
         for (let i = 0; i < originOutputs.length; i++) {
             const originOutput = originOutputs[i];
             const {
-                transactionId,
+                tracker,
                 index,
                 assetType,
                 amount,
@@ -435,7 +435,7 @@ export class Core {
                 originOutput instanceof AssetOutPoint
                     ? originOutput
                     : new AssetOutPoint({
-                          transactionId: H256.ensure(transactionId),
+                          tracker: H256.ensure(tracker),
                           index,
                           assetType: H256.ensure(assetType),
                           amount: U64.ensure(amount),
@@ -767,7 +767,7 @@ export class Core {
         assetOutPoint:
             | AssetOutPoint
             | {
-                  transactionId: H256 | string;
+                  tracker: H256 | string;
                   index: number;
                   assetType: H256 | string;
                   amount: U64 | number | string;
@@ -793,7 +793,7 @@ export class Core {
             checkUnlockScript(unlockScript);
         }
         const {
-            transactionId,
+            tracker,
             index,
             assetType,
             amount,
@@ -805,7 +805,7 @@ export class Core {
                 assetOutPoint instanceof AssetOutPoint
                     ? assetOutPoint
                     : new AssetOutPoint({
-                          transactionId: H256.ensure(transactionId),
+                          tracker: H256.ensure(tracker),
                           index,
                           assetType: H256.ensure(assetType),
                           amount: U64.ensure(amount),
@@ -821,18 +821,18 @@ export class Core {
     }
 
     public createAssetOutPoint(params: {
-        transactionId: H256 | string;
+        tracker: H256 | string;
         index: number;
         assetType: H256 | string;
         amount: U64 | number | string;
     }): AssetOutPoint {
-        const { transactionId, index, assetType, amount } = params;
-        checkTransactionId(transactionId);
+        const { tracker, index, assetType, amount } = params;
+        checkTracker(tracker);
         checkIndex(index);
         checkAssetType(assetType);
         checkAmount(amount);
         return new AssetOutPoint({
-            transactionId: H256.ensure(transactionId),
+            tracker: H256.ensure(tracker),
             index,
             assetType: H256.ensure(assetType),
             amount: U64.ensure(amount)
@@ -1048,10 +1048,10 @@ function checkTransferOutputs(outputs: Array<AssetTransferOutput>) {
     });
 }
 
-function checkTransactionId(value: H256 | string) {
+function checkTracker(value: H256 | string) {
     if (!H256.check(value)) {
         throw Error(
-            `Expected transactionId param to be an H256 value but found ${value}`
+            `Expected tracker param to be an H256 value but found ${value}`
         );
     }
 }
@@ -1074,7 +1074,7 @@ function checkAssetOutPoint(
     value:
         | AssetOutPoint
         | {
-              transactionId: H256 | string;
+              tracker: H256 | string;
               index: number;
               assetType: H256 | string;
               amount: U64 | number | string;
@@ -1088,14 +1088,14 @@ function checkAssetOutPoint(
         );
     }
     const {
-        transactionId,
+        tracker,
         index,
         assetType,
         amount,
         lockScriptHash,
         parameters
     } = value;
-    checkTransactionId(transactionId);
+    checkTracker(tracker);
     checkIndex(index);
     checkAssetType(assetType);
     checkAmount(amount);

--- a/src/core/transaction/AssetOutPoint.ts
+++ b/src/core/transaction/AssetOutPoint.ts
@@ -3,14 +3,14 @@ import { H256 } from "../H256";
 import { U64 } from "../U64";
 
 export interface AssetOutPointJSON {
-    transactionId: string;
+    tracker: string;
     index: number;
     assetType: string;
     amount: string;
 }
 
 export interface AssetOutPointData {
-    transactionId: H256;
+    tracker: H256;
     index: number;
     assetType: H256;
     amount: U64;
@@ -19,7 +19,7 @@ export interface AssetOutPointData {
 }
 
 /**
- * AssetOutPoint consists of transactionId and index, asset type, and amount.
+ * AssetOutPoint consists of tracker and index, asset type, and amount.
  *
  * - The transaction that it points to must be either AssetMint or AssetTransfer.
  * - Index is what decides which Asset to point to amongst the Asset list that transaction creates.
@@ -32,15 +32,15 @@ export class AssetOutPoint {
      * @returns An AssetOutPoint.
      */
     public static fromJSON(data: AssetOutPointJSON) {
-        const { transactionId, index, assetType, amount } = data;
+        const { tracker, index, assetType, amount } = data;
         return new this({
-            transactionId: new H256(transactionId),
+            tracker: new H256(tracker),
             index,
             assetType: new H256(assetType),
             amount: U64.ensure(amount)
         });
     }
-    public readonly transactionId: H256;
+    public readonly tracker: H256;
     public readonly index: number;
     public readonly assetType: H256;
     public readonly amount: U64;
@@ -48,7 +48,7 @@ export class AssetOutPoint {
     public readonly parameters?: Buffer[];
 
     /**
-     * @param data.transactionId A transaction hash where the Asset is created.
+     * @param data.tracker A transaction tracker where the Asset is created.
      * @param data.index The index in the output of the transaction.
      * @param data.assetType The asset type of the asset that it points to.
      * @param data.amount The asset amount of the asset that it points to.
@@ -57,14 +57,14 @@ export class AssetOutPoint {
      */
     constructor(data: AssetOutPointData) {
         const {
-            transactionId,
+            tracker,
             index,
             assetType,
             amount,
             lockScriptHash,
             parameters
         } = data;
-        this.transactionId = transactionId;
+        this.tracker = tracker;
         this.index = index;
         this.assetType = assetType;
         this.amount = amount;
@@ -76,9 +76,9 @@ export class AssetOutPoint {
      * Convert to an object for RLP encoding.
      */
     public toEncodeObject() {
-        const { transactionId, index, assetType, amount } = this;
+        const { tracker, index, assetType, amount } = this;
         return [
-            transactionId.toEncodeObject(),
+            tracker.toEncodeObject(),
             index,
             assetType.toEncodeObject(),
             amount.toEncodeObject()
@@ -90,9 +90,9 @@ export class AssetOutPoint {
      * @returns An AssetOutPoint JSON object.
      */
     public toJSON(): AssetOutPointJSON {
-        const { transactionId, index, assetType, amount } = this;
+        const { tracker, index, assetType, amount } = this;
         return {
-            transactionId: transactionId.toJSON(),
+            tracker: tracker.toJSON(),
             index,
             assetType: assetType.toJSON(),
             amount: amount.toJSON()

--- a/src/core/transaction/ComposeAsset.ts
+++ b/src/core/transaction/ComposeAsset.ts
@@ -42,10 +42,10 @@ export class ComposeAsset extends Transaction implements AssetTransaction {
     }
 
     /**
-     * Get the hash of an AssetComposeTransaction.
+     * Get the tracker of an AssetComposeTransaction.
      * @returns A transaction hash.
      */
-    public id(): H256 {
+    public tracker(): H256 {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
@@ -161,7 +161,7 @@ export class ComposeAsset extends Transaction implements AssetTransaction {
             lockScriptHash,
             parameters,
             amount: amount == null ? U64.ensure(U64.MAX_VALUE) : amount,
-            transactionId: this.id(),
+            tracker: this.tracker(),
             transactionOutputIndex: 0
         });
     }
@@ -216,7 +216,7 @@ export class ComposeAsset extends Transaction implements AssetTransaction {
     public getAssetSchemeAddress(): H256 {
         const { shardId } = this._transaction;
         const blake = blake256WithKey(
-            this.id().value,
+            this.tracker().value,
             new Uint8Array([
                 0x00,
                 0x00,
@@ -250,7 +250,7 @@ export class ComposeAsset extends Transaction implements AssetTransaction {
     public getAssetAddress(): H256 {
         const { shardId } = this._transaction;
         const blake = blake256WithKey(
-            this.id().value,
+            this.tracker().value,
             new Uint8Array([
                 0x00,
                 0x00,

--- a/src/core/transaction/DecomposeAsset.ts
+++ b/src/core/transaction/DecomposeAsset.ts
@@ -30,10 +30,10 @@ export class DecomposeAsset extends Transaction implements AssetTransaction {
     }
 
     /**
-     * Get the hash of an AssetDecomposeTransaction.
-     * @returns A transaction hash.
+     * Get the tracker of an AssetDecomposeTransaction.
+     * @returns A transaction tracker.
      */
-    public id(): H256 {
+    public tracker(): H256 {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
@@ -104,7 +104,7 @@ export class DecomposeAsset extends Transaction implements AssetTransaction {
             lockScriptHash,
             parameters,
             amount,
-            transactionId: this.id(),
+            tracker: this.tracker(),
             transactionOutputIndex: index
         });
     }
@@ -145,7 +145,7 @@ export class DecomposeAsset extends Transaction implements AssetTransaction {
         ]);
         const shardId = this._transaction.outputs[index].shardId();
 
-        const blake = blake256WithKey(this.id().value, iv);
+        const blake = blake256WithKey(this.tracker().value, iv);
         const shardPrefix = convertU16toHex(shardId);
         const prefix = `4100${shardPrefix}`;
         return new H256(

--- a/src/core/transaction/MintAsset.ts
+++ b/src/core/transaction/MintAsset.ts
@@ -27,10 +27,10 @@ export class MintAsset extends Transaction implements AssetTransaction {
     }
 
     /**
-     * Get the hash of an AssetMintTransaction.
-     * @returns A transaction hash.
+     * Get the tracker of an AssetMintTransaction.
+     * @returns A transaction tracker.
      */
-    public id(): H256 {
+    public tracker(): H256 {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
@@ -48,7 +48,7 @@ export class MintAsset extends Transaction implements AssetTransaction {
             lockScriptHash,
             parameters,
             amount,
-            transactionId: this.id(),
+            tracker: this.tracker(),
             transactionOutputIndex: 0
         });
     }
@@ -88,7 +88,7 @@ export class MintAsset extends Transaction implements AssetTransaction {
     public getAssetSchemeAddress(): H256 {
         const { shardId } = this._transaction;
         const blake = blake256WithKey(
-            this.id().value,
+            this.tracker().value,
             new Uint8Array([
                 0x00,
                 0x00,
@@ -122,7 +122,7 @@ export class MintAsset extends Transaction implements AssetTransaction {
     public getAssetAddress(): H256 {
         const { shardId } = this._transaction;
         const blake = blake256WithKey(
-            this.id().value,
+            this.tracker().value,
             new Uint8Array([
                 0x00,
                 0x00,

--- a/src/core/transaction/TransferAsset.ts
+++ b/src/core/transaction/TransferAsset.ts
@@ -40,10 +40,10 @@ export class TransferAsset extends Transaction implements AssetTransaction {
     }
 
     /**
-     * Get the hash of an AssetDecomposeTransaction.
-     * @returns A transaction hash.
+     * Get the tracker of an AssetDecomposeTransaction.
+     * @returns A transaction tracker.
      */
-    public id(): H256 {
+    public tracker(): H256 {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
@@ -210,7 +210,7 @@ export class TransferAsset extends Transaction implements AssetTransaction {
             lockScriptHash,
             parameters,
             amount,
-            transactionId: this.id(),
+            tracker: this.tracker(),
             transactionOutputIndex: index
         });
     }
@@ -322,7 +322,7 @@ export class TransferAsset extends Transaction implements AssetTransaction {
         ]);
         const shardId = this._transaction.outputs[index].shardId();
 
-        const blake = blake256WithKey(this.id().value, iv);
+        const blake = blake256WithKey(this.tracker().value, iv);
         const shardPrefix = convertU16toHex(shardId);
         const prefix = `4100${shardPrefix}`;
         return new H256(

--- a/src/core/transaction/UnwrapCCC.ts
+++ b/src/core/transaction/UnwrapCCC.ts
@@ -60,7 +60,7 @@ export class UnwrapCCC extends Transaction implements AssetTransaction {
         return this._transaction.burn;
     }
 
-    public id() {
+    public tracker() {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 

--- a/src/core/transaction/WrapCCC.ts
+++ b/src/core/transaction/WrapCCC.ts
@@ -88,12 +88,12 @@ export class WrapCCC extends Transaction implements AssetTransaction {
             lockScriptHash,
             parameters,
             amount,
-            transactionId: this.id(),
+            tracker: this.tracker(),
             transactionOutputIndex: 0
         });
     }
 
-    public id() {
+    public tracker() {
         return this.hash();
     }
 

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -193,7 +193,7 @@ export class Key {
         const accountId = PlatformAddress.ensure(account).getAccountId();
         return await keyStore.platform.sign({
             key: accountId.value,
-            message: transaction.id().value,
+            message: transaction.tracker().value,
             passphrase
         });
     }

--- a/src/rpc/__test__/invalid-response.spec.ts
+++ b/src/rpc/__test__/invalid-response.spec.ts
@@ -171,7 +171,7 @@ describe("Invalid response", () => {
             test("undefined", done => {
                 rpc.sendRpcRequest = jest.fn().mockResolvedValueOnce(undefined);
                 chainRpc
-                    .getTransactionById(hash)
+                    .getTransactionByTracker(hash)
                     .then(() => done.fail())
                     .catch(e => {
                         expect(e.toString()).toContain("chain_getTransaction");
@@ -189,11 +189,11 @@ describe("Invalid response", () => {
             });
         });
 
-        describe("getInvoicesById", () => {
+        describe("getInvoicesByTracker", () => {
             test("undefined", done => {
                 rpc.sendRpcRequest = jest.fn().mockResolvedValueOnce([]);
                 chainRpc
-                    .getInvoicesById(hash)
+                    .getInvoicesByTracker(hash)
                     .then(invoices => {
                         expect(invoices).toEqual([]);
                         done();
@@ -279,15 +279,15 @@ describe("Invalid response", () => {
             test.skip("Invalid number", done => done.fail("not implemented"));
         });
 
-        describe("getAssetSchemeByHash", () => {
+        describe("getAssetSchemeByTracker", () => {
             test("undefined", done => {
                 rpc.sendRpcRequest = jest.fn().mockResolvedValueOnce(undefined);
                 chainRpc
-                    .getAssetSchemeByHash(hash, 0)
+                    .getAssetSchemeByTracker(hash, 0)
                     .then(() => done.fail())
                     .catch(e => {
                         expect(e.toString()).toContain(
-                            "chain_getAssetSchemeByHash"
+                            "chain_getAssetSchemeByTracker"
                         );
                         expect(e.toString()).toContain("JSON of AssetScheme");
                         expect(e.toString()).toContain("undefined");

--- a/src/rpc/chain.ts
+++ b/src/rpc/chain.ts
@@ -296,21 +296,21 @@ export class ChainRpc {
 
     /**
      * Gets a transaction of given hash.
-     * @param txId The transaction hash of which to get the corresponding transaction of.
+     * @param tracker The tracker of which to get the corresponding transaction of.
      * @returns A transaction, or null when transaction of given hash not exists.
      */
-    public getTransactionById(
-        txId: H256 | string
+    public getTransactionByTracker(
+        tracker: H256 | string
     ): Promise<SignedTransaction | null> {
-        if (!H256.check(txId)) {
+        if (!H256.check(tracker)) {
             throw Error(
-                `Expected the first argument of getTransaction to be an H256 value but found ${txId}`
+                `Expected the first argument of getTransactionByTracker to be an H256 value but found ${tracker}`
             );
         }
         return new Promise((resolve, reject) => {
             this.rpc
-                .sendRpcRequest("chain_getTransactionById", [
-                    `0x${H256.ensure(txId).value}`
+                .sendRpcRequest("chain_getTransactionByTracker", [
+                    `0x${H256.ensure(tracker).value}`
                 ])
                 .then(result => {
                     try {
@@ -322,7 +322,7 @@ export class ChainRpc {
                     } catch (e) {
                         reject(
                             Error(
-                                `Expected chain_getTransactionById to return either null or JSON of Transaction, but an error occurred: ${e.toString()}`
+                                `Expected chain_getTransactionByTracker to return either null or JSON of Transaction, but an error occurred: ${e.toString()}`
                             )
                         );
                     }
@@ -332,23 +332,23 @@ export class ChainRpc {
     }
 
     /**
-     * Gets invoice of a transaction of given hash.
-     * @param txId The transaction hash of which to get the corresponding transaction of.
+     * Gets invoice of a transaction of given tracker.
+     * @param tracker The transaction hash of which to get the corresponding transaction of.
      * @param options.timeout Indicating milliseconds to wait the transaction to be confirmed.
      * @returns Invoice, or null when transaction of given hash not exists.
      */
-    public async getInvoicesById(
-        txId: H256 | string,
+    public async getInvoicesByTracker(
+        tracker: H256 | string,
         options: { timeout?: number } = {}
     ): Promise<Invoice[]> {
-        if (!H256.check(txId)) {
+        if (!H256.check(tracker)) {
             throw Error(
-                `Expected the first argument of getInvoice to be an H256 value but found ${txId}`
+                `Expected the first argument of getInvoicesByTracker to be an H256 value but found ${tracker}`
             );
         }
         const attemptToGet = async () => {
-            return this.rpc.sendRpcRequest("chain_getInvoicesById", [
-                `0x${H256.ensure(txId).value}`
+            return this.rpc.sendRpcRequest("chain_getInvoicesByTracker", [
+                `0x${H256.ensure(tracker).value}`
             ]);
         };
         const startTime = Date.now();
@@ -358,7 +358,7 @@ export class ChainRpc {
             (typeof timeout !== "number" || timeout < 0)
         ) {
             throw Error(
-                `Expected timeout param of getInvoice to be non-negative number but found ${timeout}`
+                `Expected timeout param of getInvoicesByTracker to be non-negative number but found ${timeout}`
             );
         }
         let result = await attemptToGet();
@@ -377,7 +377,7 @@ export class ChainRpc {
             return result.map(Invoice.fromJSON);
         } catch (e) {
             throw Error(
-                `Expected chain_getInvoicesById to return JSON of Invoice[], but an error occurred: ${e.toString()}. received: ${JSON.stringify(
+                `Expected chain_getInvoicesByTracker to return JSON of Invoice[], but an error occurred: ${e.toString()}. received: ${JSON.stringify(
                     result
                 )}`
             );
@@ -548,36 +548,36 @@ export class ChainRpc {
     }
 
     /**
-     * Gets asset scheme of given hash of AssetMintTransaction.
-     * @param txhash The tx hash of AssetMintTransaction.
+     * Gets asset scheme of given tracker of the mint transaction.
+     * @param tracker The tracker of the mint transaction.
      * @param shardId The shard id of Asset Scheme.
      * @param blockNumber The specific block number to get the asset scheme from
      * @returns AssetScheme, if asset scheme exists. Else, returns null.
      */
-    public getAssetSchemeByHash(
-        txhash: H256 | string,
+    public getAssetSchemeByTracker(
+        tracker: H256 | string,
         shardId: number,
         blockNumber?: number | null
     ): Promise<AssetScheme | null> {
-        if (!H256.check(txhash)) {
+        if (!H256.check(tracker)) {
             throw Error(
-                `Expected the first arugment of getAssetSchemeByHash to be an H256 value but found ${txhash}`
+                `Expected the first arugment of getAssetSchemeByTracker to be an H256 value but found ${tracker}`
             );
         }
         if (!isShardIdValue(shardId)) {
             throw Error(
-                `Expected the second argument of getAssetSchemeByHash to be a shard ID value but found ${shardId}`
+                `Expected the second argument of getAssetSchemeByTracker to be a shard ID value but found ${shardId}`
             );
         }
         if (blockNumber !== undefined && !isNonNegativeInterger(blockNumber)) {
             throw Error(
-                `Expected the third argument of getAssetSchemeByHash to be non-negative integer but found ${blockNumber}`
+                `Expected the third argument of getAssetSchemeByTracker to be non-negative integer but found ${blockNumber}`
             );
         }
         return new Promise((resolve, reject) => {
             this.rpc
-                .sendRpcRequest("chain_getAssetSchemeByHash", [
-                    `0x${H256.ensure(txhash).value}`,
+                .sendRpcRequest("chain_getAssetSchemeByTracker", [
+                    `0x${H256.ensure(tracker).value}`,
                     shardId,
                     blockNumber
                 ])
@@ -591,7 +591,7 @@ export class ChainRpc {
                     } catch (e) {
                         reject(
                             Error(
-                                `Expected chain_getAssetSchemeByHash to return either null or JSON of AssetScheme, but an error occurred: ${e.toString()}`
+                                `Expected chain_getAssetSchemeByTracker to return either null or JSON of AssetScheme, but an error occurred: ${e.toString()}`
                             )
                         );
                     }
@@ -647,19 +647,19 @@ export class ChainRpc {
 
     /**
      * Gets asset of given transaction hash and index.
-     * @param txId The tx hash of AssetMintTransaction or AssetTransferTransaction.
+     * @param tracker The tracker of previous input transaction.
      * @param index The index of output in the transaction.
      * @param blockNumber The specific block number to get the asset from
      * @returns Asset, if asset exists, Else, returns null.
      */
     public getAsset(
-        txId: H256 | string,
+        tracker: H256 | string,
         index: number,
         blockNumber?: number
     ): Promise<Asset | null> {
-        if (!H256.check(txId)) {
+        if (!H256.check(tracker)) {
             throw Error(
-                `Expected the first argument of getAsset to be an H256 value but found ${txId}`
+                `Expected the first argument of getAsset to be an H256 value but found ${tracker}`
             );
         }
         if (!isNonNegativeInterger(index)) {
@@ -675,7 +675,7 @@ export class ChainRpc {
         return new Promise((resolve, reject) => {
             this.rpc
                 .sendRpcRequest("chain_getAsset", [
-                    `0x${H256.ensure(txId).value}`,
+                    `0x${H256.ensure(tracker).value}`,
                     index,
                     blockNumber
                 ])
@@ -687,7 +687,7 @@ export class ChainRpc {
                         resolve(
                             Asset.fromJSON({
                                 ...result,
-                                transactionId: H256.ensure(txId).value,
+                                tracker: H256.ensure(tracker).value,
                                 transactionOutputIndex: index
                             })
                         );


### PR DESCRIPTION
And it renames the below APIs.
1. getTransactionById -> getTransactionByTracker
2. getInvoicesById -> getInvoicesByTracker
3. getAssetSchemeByHash -> getAssetSchemeByTracker