### PR TITLE
Change serialized type of parameters to string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ node_js:
 before_install:
   - yarn install
 before_script:
-  - docker pull kodebox/codechain:ed509c144b3fc1211fa3c8e0057e637925736274
-  - docker run -d -p 8080:8080 kodebox/codechain:ed509c144b3fc1211fa3c8e0057e637925736274 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
+  - docker pull kodebox/codechain:6f11ca1ce932945a5d5e005d7fc7c742016e8de0
+  - docker run -d -p 8080:8080 kodebox/codechain:6f11ca1ce932945a5d5e005d7fc7c742016e8de0 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
   - docker ps -a
 script:
   - yarn test --verbose

--- a/src/core/Asset.ts
+++ b/src/core/Asset.ts
@@ -12,7 +12,7 @@ import { U64 } from "./U64";
 export interface AssetJSON {
     assetType: string;
     lockScriptHash: string;
-    parameters: number[][];
+    parameters: string[];
     amount: string;
     orderHash: string | null;
     // The `hash` and the `index` are not included in an RPC response. See
@@ -47,9 +47,7 @@ export class Asset {
         return new Asset({
             assetType: new H256(assetType),
             lockScriptHash: new H160(lockScriptHash),
-            parameters: parameters.map((p: Buffer | number[]) =>
-                Buffer.from(p)
-            ),
+            parameters: parameters.map((p: string) => Buffer.from(p, "hex")),
             amount: U64.ensure(amount),
             orderHash: orderHash === null ? orderHash : H256.ensure(orderHash),
             tracker: new H256(tracker),
@@ -102,7 +100,7 @@ export class Asset {
         return {
             assetType: assetType.toJSON(),
             lockScriptHash: lockScriptHash.toJSON(),
-            parameters: parameters.map(p => [...p]),
+            parameters: parameters.map((p: Buffer) => p.toString("hex")),
             amount: amount.toJSON(),
             orderHash: orderHash === null ? null : orderHash.toJSON(),
             tracker: tracker.toJSON(),

--- a/src/core/transaction/AssetMintOutput.ts
+++ b/src/core/transaction/AssetMintOutput.ts
@@ -7,7 +7,7 @@ import { U64 } from "../U64";
 
 export interface AssetMintOutputJSON {
     lockScriptHash: string;
-    parameters: number[][];
+    parameters: string[];
     amount?: string | null;
 }
 
@@ -21,7 +21,7 @@ export class AssetMintOutput {
         const { lockScriptHash, parameters, amount } = data;
         return new this({
             lockScriptHash: H160.ensure(lockScriptHash),
-            parameters: parameters.map(p => Buffer.from(p)),
+            parameters: parameters.map(p => Buffer.from(p, "hex")),
             amount: amount == null ? null : U64.ensure(amount)
         });
     }
@@ -88,7 +88,7 @@ export class AssetMintOutput {
     public toJSON(): AssetMintOutputJSON {
         return {
             lockScriptHash: this.lockScriptHash.toJSON(),
-            parameters: this.parameters.map(p => [...p]),
+            parameters: this.parameters.map((p: Buffer) => p.toString("hex")),
             amount: this.amount == null ? undefined : this.amount.toJSON()
         };
     }

--- a/src/core/transaction/AssetTransferOutput.ts
+++ b/src/core/transaction/AssetTransferOutput.ts
@@ -9,7 +9,7 @@ import { U64 } from "../U64";
 
 export interface AssetTransferOutputJSON {
     lockScriptHash: string;
-    parameters: number[][];
+    parameters: string[];
     assetType: string;
     amount: string;
 }
@@ -42,9 +42,7 @@ export class AssetTransferOutput {
         const { lockScriptHash, parameters, assetType, amount } = data;
         return new AssetTransferOutput({
             lockScriptHash: H160.ensure(lockScriptHash),
-            parameters: parameters.map((p: number[] | Buffer) =>
-                Buffer.from(p)
-            ),
+            parameters: parameters.map((p: string) => Buffer.from(p, "hex")),
             assetType: H256.ensure(assetType),
             amount: U64.ensure(amount)
         });
@@ -120,7 +118,7 @@ export class AssetTransferOutput {
         const { lockScriptHash, parameters, assetType, amount } = this;
         return {
             lockScriptHash: lockScriptHash.toJSON(),
-            parameters: parameters.map(parameter => [...parameter]),
+            parameters: parameters.map((p: Buffer) => p.toString("hex")),
             assetType: assetType.toJSON(),
             amount: amount.toJSON()
         };

--- a/src/core/transaction/Order.ts
+++ b/src/core/transaction/Order.ts
@@ -22,9 +22,9 @@ export interface OrderJSON {
     originOutputs: AssetOutPointJSON[];
     expiration: string;
     lockScriptHashFrom: string;
-    parametersFrom: number[][];
+    parametersFrom: string[];
     lockScriptHashFee: string;
-    parametersFee: number[][];
+    parametersFee: string[];
 }
 
 export interface OrderDataBasic {
@@ -84,12 +84,12 @@ export class Order {
             ),
             expiration: U64.ensure(expiration),
             lockScriptHashFrom: new H160(lockScriptHashFrom),
-            parametersFrom: parametersFrom.map((p: Buffer | number[]) =>
-                Buffer.from(p)
+            parametersFrom: parametersFrom.map((p: string) =>
+                Buffer.from(p, "hex")
             ),
             lockScriptHashFee: new H160(lockScriptHashFee),
-            parametersFee: parametersFee.map((p: Buffer | number[]) =>
-                Buffer.from(p)
+            parametersFee: parametersFee.map((p: string) =>
+                Buffer.from(p, "hex")
             )
         });
     }
@@ -285,9 +285,11 @@ export class Order {
             originOutputs: originOutputs.map(output => output.toJSON()),
             expiration: expiration.toString(),
             lockScriptHashFrom: lockScriptHashFrom.toJSON(),
-            parametersFrom: parametersFrom.map(parameter => [...parameter]),
+            parametersFrom: parametersFrom.map((p: Buffer) =>
+                p.toString("hex")
+            ),
             lockScriptHashFee: lockScriptHashFee.toJSON(),
-            parametersFee: parametersFee.map(parameter => [...parameter])
+            parametersFee: parametersFee.map((p: Buffer) => p.toString("hex"))
         };
     }
 

--- a/src/core/transaction/WrapCCC.ts
+++ b/src/core/transaction/WrapCCC.ts
@@ -117,7 +117,7 @@ export class WrapCCC extends Transaction implements AssetTransaction {
         return {
             shardId,
             lockScriptHash: lockScriptHash.toJSON(),
-            parameters: parameters.map(parameter => [...parameter]),
+            parameters: parameters.map((p: Buffer) => p.toString("hex")),
             amount: amount.toJSON()
         };
     }

--- a/src/core/transaction/json.ts
+++ b/src/core/transaction/json.ts
@@ -192,8 +192,8 @@ export function fromJSONToTransaction(result: any): Transaction {
         case "wrapCCC": {
             const shardId = action.shardId;
             const lockScriptHash = H160.ensure(action.lockScriptHash);
-            const parameters = action.parameters.map((p: number[] | Buffer) =>
-                Buffer.from(p)
+            const parameters = action.parameters.map((p: string) =>
+                Buffer.from(p, "hex")
             );
             const amount = U64.ensure(action.amount);
             tx = new WrapCCC(


### PR DESCRIPTION
To keep pace with the change of parameters' serialization type in
codechain core, toJSON and fromJSON function have been changed
properly.