### PR TITLE
Fix a bug in Transaction.toJSON()

### DIFF
--- a/src/core/SignedTransaction.ts
+++ b/src/core/SignedTransaction.ts
@@ -184,15 +184,11 @@ export class SignedTransaction {
             r,
             s
         } = this;
-        const seq = unsigned.seq();
         const sig = SignedTransaction.convertRsvToSignatureString({
             r: r.value.toString(16),
             s: s.value.toString(16),
             v
         });
-        if (seq == null) {
-            throw Error("Signed tx must have the seq");
-        }
         const result = unsigned.toJSON();
         result.blockNumber = blockNumber;
         result.blockHash = blockHash === null ? null : blockHash.toJSON();

--- a/src/core/Transaction.ts
+++ b/src/core/Transaction.ts
@@ -97,18 +97,17 @@ export abstract class Transaction {
         const seq = this._seq;
         const fee = this._fee;
         const networkId = this._networkId;
-        if (!fee) {
-            throw Error("Transaction must have the fee");
-        }
         const action = this.actionToJSON();
         action.type = this.type();
         const result: any = {
-            fee: fee.toJSON(),
             networkId,
             action
         };
         if (seq != null) {
             result.seq = seq;
+        }
+        if (fee != null) {
+            result.fee = fee.toJSON();
         }
         return result;
     }


### PR DESCRIPTION
This patch changes the `toJSON` function not to throw an error even if either `fee` or `seq` is `null`. 