### PR TITLE
Change the EcdsaSignature type from the rsv interface to string

### DIFF
--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -8,7 +8,6 @@ import {
     SignedTransaction,
     Transaction,
     TransferAsset,
-    U256,
     U64
 } from "../lib/core/classes";
 import {
@@ -281,7 +280,8 @@ describe("rpc", () => {
 
             test("VerificationFailed", done => {
                 const signed = tx.sign({ secret: signerSecret, fee: 10, seq });
-                signed.r = new U256(0);
+                (signed as any)._signature =
+                    "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
                 sdk.rpc.chain
                     .sendSignedTransaction(signed)
                     .then(() => done.fail())
@@ -683,15 +683,12 @@ describe("rpc", () => {
             });
 
             test("Ok", async () => {
-                const { r, s, v } = signEcdsa(message, secret);
                 const signature = await sdk.rpc.account.sign(
                     message,
                     address,
                     "my-password"
                 );
-                expect(signature).toContain(r);
-                expect(signature).toContain(s);
-                expect(signature).toContain(v);
+                expect(signature).toContain(signEcdsa(message, secret));
             });
 
             test("WrongPassword", async done => {

--- a/src/__test__/secp256k1.spec.ts
+++ b/src/__test__/secp256k1.spec.ts
@@ -1,8 +1,8 @@
 import {
-    signEcdsa,
-    verifyEcdsa,
+    getPublicFromPrivate,
     recoverEcdsa,
-    getPublicFromPrivate
+    signEcdsa,
+    verifyEcdsa
 } from "../utils";
 
 const priv = "99053a6568a93b9f194ef983c84ddfa9eb2b37888e47433558d40b2f4770b2d8";
@@ -15,23 +15,15 @@ test("public key", () => {
 
 test("sign", () => {
     const signature = signEcdsa(msg, priv);
-    expect(signature).toEqual({
-        r: "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c7",
-        s: "19d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f375",
-        v: 0
-    });
+    expect(signature).toEqual(
+        "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c719d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f37500"
+    );
 });
 
 test("verify - success", () => {
     const result = verifyEcdsa(
         msg,
-        {
-            r:
-                "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c7",
-            s:
-                "19d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f375",
-            v: 0
-        },
+        "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c719d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f37500",
         getPublicFromPrivate(priv)
     );
     expect(result).toBe(true);
@@ -40,23 +32,16 @@ test("verify - success", () => {
 test("verify - fail", () => {
     const result = verifyEcdsa(
         "0000000000000000000000000000000000000000000000000000000000000000",
-        {
-            r:
-                "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c7",
-            s:
-                "19d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f375",
-            v: 0
-        },
+        "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c719d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f37500",
         getPublicFromPrivate(priv)
     );
     expect(result).toBe(false);
 });
 
 test("recover", () => {
-    const a = recoverEcdsa(msg, {
-        r: "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c7",
-        s: "19d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f375",
-        v: 0
-    });
+    const a = recoverEcdsa(
+        msg,
+        "d8706a863775325b1b8c3f16c19ff337c2699c4f857be903e08a5a9234c5a5c719d685ae28e52081480b08a3a1e5d8dd1f852b78f65a7e99af37ad42ebc5f37500"
+    );
     expect(a).toBe(getPublicFromPrivate(priv));
 });

--- a/src/core/Transaction.ts
+++ b/src/core/Transaction.ts
@@ -85,12 +85,10 @@ export abstract class Transaction {
             throw Error("The tx fee is already set");
         }
         this._fee = U64.ensure(fee);
-        const { r, s, v } = signEcdsa(
-            this.hash().value,
-            H256.ensure(secret).value
+        return new SignedTransaction(
+            this,
+            signEcdsa(this.hash().value, H256.ensure(secret).value)
         );
-        const sig = SignedTransaction.convertRsvToSignatureString({ r, s, v });
-        return new SignedTransaction(this, sig);
     }
 
     public toJSON() {

--- a/src/core/__test__/Transaction.spec.ts
+++ b/src/core/__test__/Transaction.spec.ts
@@ -83,17 +83,8 @@ test("sign", () => {
         seq: 0,
         fee: 0
     });
-    const { v, r, s } = signed.signature();
-    expect(v).toBe(1);
-    expect(r.toEncodeObject()).toEqual(
-        new U256(
-            "0x3f9bcff484bd5f1d5549f912f9eeaf8c2fe349b257bde2b61fb1036013d4e44c"
-        ).toEncodeObject()
-    );
-    expect(s.toEncodeObject()).toEqual(
-        new U256(
-            "0x204a4215d26cb879eaad2028fe1a7898e4cf9a5d979eb383e0a384140d6e04c1"
-        ).toEncodeObject()
+    expect(signed.signature()).toBe(
+        "3f9bcff484bd5f1d5549f912f9eeaf8c2fe349b257bde2b61fb1036013d4e44c204a4215d26cb879eaad2028fe1a7898e4cf9a5d979eb383e0a384140d6e04c101"
     );
 });
 

--- a/src/core/transaction/Remove.ts
+++ b/src/core/transaction/Remove.ts
@@ -26,12 +26,7 @@ export class Remove extends Transaction {
         if ("secret" in params) {
             const { hash, secret } = params;
             this._hash = hash;
-            const { r, s, v } = signEcdsa(hash.value, secret.value);
-            this.signature = `${_.padStart(r, 64, "0")}${_.padStart(
-                s,
-                64,
-                "0"
-            )}${_.padStart(v.toString(16), 2, "0")}`;
+            this.signature = signEcdsa(hash.value, secret.value);
         } else {
             let signature = params.signature;
             if (signature.startsWith("0x")) {

--- a/src/core/transaction/Store.ts
+++ b/src/core/transaction/Store.ts
@@ -34,15 +34,10 @@ export class Store extends Transaction {
                 getPublicFromPrivate(secret.value),
                 { networkId }
             );
-            const { r, s, v } = signEcdsa(
+            this.signature = signEcdsa(
                 blake256(RLP.encode(content)),
                 secret.value
             );
-            this.signature = `${_.padStart(r, 64, "0")}${_.padStart(
-                s,
-                64,
-                "0"
-            )}${_.padStart(v.toString(16), 2, "0")}`;
         } else {
             const { content, certifier } = params;
             let signature = params.signature;

--- a/src/key/MemoryKeyStore.ts
+++ b/src/key/MemoryKeyStore.ts
@@ -80,13 +80,7 @@ class KeyManager implements KeyManagementAPI {
         if (passphrase !== this.passphraseMap[key]) {
             return Promise.reject("The passphrase does not match");
         }
-        const { r, s, v } = signEcdsa(message, this.privateKeyMap[key]);
-        const sig = `${_.padStart(r, 64, "0")}${_.padStart(
-            s,
-            64,
-            "0"
-        )}${_.padStart(v.toString(16), 2, "0")}`;
-        return Promise.resolve(sig);
+        return Promise.resolve(signEcdsa(message, this.privateKeyMap[key]));
     }
 }
 

--- a/src/key/__test__/LocalKeyStore.spec.ts
+++ b/src/key/__test__/LocalKeyStore.spec.ts
@@ -56,10 +56,6 @@ test("sign", async () => {
         key,
         message
     });
-    const r = `${signature.substr(0, 64)}`;
-    const s = `${signature.substr(64, 64)}`;
-    const v = Number.parseInt(signature.substr(128, 2), 16);
-
-    expect(verifyEcdsa(message, { r, s, v }, publicKey)).toBe(true);
-    expect(recoverEcdsa(message, { r, s, v })).toEqual(publicKey);
+    expect(verifyEcdsa(message, signature, publicKey)).toBe(true);
+    expect(recoverEcdsa(message, signature)).toEqual(publicKey);
 });

--- a/src/key/__test__/MemoryKeyStore.spec.ts
+++ b/src/key/__test__/MemoryKeyStore.spec.ts
@@ -1,8 +1,8 @@
 import {
-    recoverEcdsa,
-    verifyEcdsa,
+    getAccountIdFromPublic,
     getPublicFromPrivate,
-    getAccountIdFromPublic
+    recoverEcdsa,
+    verifyEcdsa
 } from "../../utils";
 import { MemoryKeyStore } from "../MemoryKeyStore";
 
@@ -53,10 +53,6 @@ test("sign", async () => {
         key,
         message
     });
-    const r = `${signature.substr(0, 64)}`;
-    const s = `${signature.substr(64, 64)}`;
-    const v = Number.parseInt(signature.substr(128, 2), 16);
-
-    expect(verifyEcdsa(message, { r, s, v }, publicKey)).toBe(true);
-    expect(recoverEcdsa(message, { r, s, v })).toEqual(publicKey);
+    expect(verifyEcdsa(message, signature, publicKey)).toBe(true);
+    expect(recoverEcdsa(message, signature)).toEqual(publicKey);
 });


### PR DESCRIPTION
Issue: https://github.com/CodeChain-io/codechain-sdk-js/issues/269

The following util functions are affected by this change.

- signEcdsa
- verifyEcdsa
- recoverEcdsa