### PR TITLE
Rename the hash() of Transaction to unsignedHash

### DIFF
--- a/src/core/SignedTransaction.ts
+++ b/src/core/SignedTransaction.ts
@@ -106,7 +106,10 @@ export class SignedTransaction {
      */
     public getSignerAccountId(): H160 {
         const { _signature, unsigned } = this;
-        const publicKey = recoverEcdsa(unsigned.hash().value, _signature);
+        const publicKey = recoverEcdsa(
+            unsigned.unsignedHash().value,
+            _signature
+        );
         return new H160(blake160(publicKey));
     }
 
@@ -125,7 +128,9 @@ export class SignedTransaction {
      */
     public getSignerPublic(): H512 {
         const { _signature, unsigned } = this;
-        return new H512(recoverEcdsa(unsigned.hash().value, _signature));
+        return new H512(
+            recoverEcdsa(unsigned.unsignedHash().value, _signature)
+        );
     }
 
     /**

--- a/src/core/Transaction.ts
+++ b/src/core/Transaction.ts
@@ -106,7 +106,7 @@ export abstract class Transaction {
         return RLP.encode(this.toEncodeObject());
     }
 
-    public hash(): H256 {
+    public unsignedHash(): H256 {
         return new H256(blake256(this.rlpBytes()));
     }
 
@@ -126,7 +126,7 @@ export abstract class Transaction {
         this._fee = U64.ensure(fee);
         return new SignedTransaction(
             this,
-            signEcdsa(this.hash().value, H256.ensure(secret).value)
+            signEcdsa(this.unsignedHash().value, H256.ensure(secret).value)
         );
     }
 

--- a/src/core/__test__/Transaction.spec.ts
+++ b/src/core/__test__/Transaction.spec.ts
@@ -61,7 +61,7 @@ test("hash", () => {
     );
     t.setFee(0);
     t.setSeq(0);
-    expect(t.hash()).toEqual(
+    expect(t.unsignedHash()).toEqual(
         new H256(
             "3b578bebb32cae770ab1094d572a4721b624fc101bb88fbc580eeb2931f65665"
         )

--- a/src/core/transaction/WrapCCC.ts
+++ b/src/core/transaction/WrapCCC.ts
@@ -104,7 +104,7 @@ export class WrapCCC extends Transaction implements AssetTransaction {
     }
 
     public tracker() {
-        return this.hash();
+        return this.unsignedHash();
     }
 
     public type(): string {

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -254,7 +254,7 @@ export class Key {
         const accountId = PlatformAddress.ensure(account).getAccountId();
         const sig = await keyStore.platform.sign({
             key: accountId.value,
-            message: tx.hash().value,
+            message: tx.unsignedHash().value,
             passphrase
         });
         return new SignedTransaction(tx, sig);

--- a/src/rpc/chain.ts
+++ b/src/rpc/chain.ts
@@ -112,7 +112,11 @@ export class ChainRpc {
         }
         tx.setFee(fee);
         const address = PlatformAddress.ensure(account);
-        const sig = await this.rpc.account.sign(tx.hash(), address, passphrase);
+        const sig = await this.rpc.account.sign(
+            tx.unsignedHash(),
+            address,
+            passphrase
+        );
         return this.sendSignedTransaction(new SignedTransaction(tx, sig));
     }
 


### PR DESCRIPTION
We're renaming it because it's confused with the hash() of SignedTransaction.