### PR TITLE
Change examples to special users be active account

### DIFF
--- a/examples/create-shard-and-set-owners.js
+++ b/examples/create-shard-and-set-owners.js
@@ -12,6 +12,16 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 (async () => {
     const account2 = await sdk.rpc.account.create();
+    await sdk.rpc.chain.sendTransaction(
+        sdk.core.createPayTransaction({
+            recipient: account2,
+            quantity: 1
+        }),
+        {
+            account: ACCOUNT_ADDRESS,
+            passphrase: ACCOUNT_PASSPHRASE
+        }
+    );
     const createShardTxHash = await sdk.rpc.chain.sendTransaction(
         sdk.core.createCreateShardTransaction({
             users: [account2]

--- a/examples/create-shard-and-set-users.js
+++ b/examples/create-shard-and-set-users.js
@@ -12,6 +12,16 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
 
 (async () => {
     const account2 = await sdk.rpc.account.create();
+    await sdk.rpc.chain.sendTransaction(
+        sdk.core.createPayTransaction({
+            recipient: account2,
+            quantity: 1
+        }),
+        {
+            account: ACCOUNT_ADDRESS,
+            passphrase: ACCOUNT_PASSPHRASE
+        }
+    );
     const createShardTxHash = await sdk.rpc.chain.sendTransaction(
         sdk.core.createCreateShardTransaction({
             users: [account2]

--- a/examples/mint-and-change-scheme.js
+++ b/examples/mint-and-change-scheme.js
@@ -52,6 +52,27 @@ const ACCOUNT_PASSPHRASE = process.env.ACCOUNT_PASSPHRASE || "satoshi";
         );
     }
 
+    await sdk.rpc.chain.sendTransaction(
+        sdk.core.createPayTransaction({
+            recipient: bobAddress,
+            quantity: 1
+        }),
+        {
+            account: ACCOUNT_ADDRESS,
+            passphrase: ACCOUNT_PASSPHRASE
+        }
+    );
+    await sdk.rpc.chain.sendTransaction(
+        sdk.core.createPayTransaction({
+            recipient: carolAddress,
+            quantity: 1
+        }),
+        {
+            account: ACCOUNT_ADDRESS,
+            passphrase: ACCOUNT_PASSPHRASE
+        }
+    );
+
     const assetSchemeChangeTx = sdk.core.createChangeAssetSchemeTransaction({
         assetType: mintTx.getMintedAsset().assetType,
         shardId,


### PR DESCRIPTION
CodeChain will have a restriction that allows only the active account,
who has seq or balance, be special users(shard owner, asset approver,
...).
It fixes an examples to follow the restriction.