### PR TITLE
Add range parameters to the rpc 'getPendingTransactions'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ node_js:
 before_install:
   - yarn install
 before_script:
-  - docker pull kodebox/codechain:de17013539024a5a4e87e87d290e3cab522070e6
-  - docker run -d -p 8080:8080 kodebox/codechain:de17013539024a5a4e87e87d290e3cab522070e6 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
+  - docker pull kodebox/codechain:b4f5ad915769294365590632dfbb176f2d823ce2
+  - docker run -d -p 8080:8080 kodebox/codechain:b4f5ad915769294365590632dfbb176f2d823ce2 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0
   - docker ps -a
 script:
   - yarn test --verbose

--- a/integration_tests/Rpc.spec.ts
+++ b/integration_tests/Rpc.spec.ts
@@ -400,7 +400,7 @@ describe("rpc", () => {
         describe.skip("with pending transactions", () => {
             test("getPendingTransactions", async () => {
                 const pendingTransactions = await sdk.rpc.chain.getPendingTransactions();
-                expect(pendingTransactions[0]).toEqual(
+                expect(pendingTransactions.transactions[0]).toEqual(
                     expect.any(SignedTransaction)
                 );
             });

--- a/src/core/__test__/Transaction.spec.ts
+++ b/src/core/__test__/Transaction.spec.ts
@@ -1,4 +1,4 @@
-import { H256, PlatformAddress, U256, U64 } from "codechain-primitives";
+import { H256, PlatformAddress, U64 } from "codechain-primitives";
 import { Pay } from "../transaction/Pay";
 
 import { fromJSONToTransaction } from "../transaction/json";

--- a/src/rpc/__test__/invalid-response.spec.ts
+++ b/src/rpc/__test__/invalid-response.spec.ts
@@ -365,7 +365,8 @@ describe("Invalid response", () => {
                         expect(e.toString()).toContain(
                             "chain_getPendingTransactions"
                         );
-                        expect(e.toString()).toContain("array");
+                        expect(e.toString()).toContain("transactions");
+                        expect(e.toString()).toContain("lastTimestamp");
                         expect(e.toString()).toContain("undefined");
                         done();
                     });


### PR DESCRIPTION
Now rpc `getPendingTransactions` returns new property `lastTimestamp` which is the last timestamp value among the returned `transactions`