### PR TITLE
Add addApproval method

### DIFF
--- a/src/core/Transaction.ts
+++ b/src/core/Transaction.ts
@@ -24,7 +24,9 @@ const RLP = require("rlp");
 
 export interface AssetTransaction {
     tracker(): H256;
+    addApproval(approval: string): void;
 }
+
 type ActionJSON =
     | PayActionJSON
     | SetRegularKeyActionJSON

--- a/src/core/transaction/ChangeAssetScheme.ts
+++ b/src/core/transaction/ChangeAssetScheme.ts
@@ -47,6 +47,14 @@ export class ChangeAssetScheme extends Transaction {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
+    /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
     public type(): string {
         return "changeAssetScheme";
     }

--- a/src/core/transaction/ComposeAsset.ts
+++ b/src/core/transaction/ComposeAsset.ts
@@ -68,6 +68,14 @@ export class ComposeAsset extends Transaction implements AssetTransaction {
     }
 
     /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
+    /**
      * Get a hash of the transaction that doesn't contain the scripts. The hash
      * is used as a message to create a signature for a transaction.
      * @returns A hash.

--- a/src/core/transaction/DecomposeAsset.ts
+++ b/src/core/transaction/DecomposeAsset.ts
@@ -53,6 +53,14 @@ export class DecomposeAsset extends Transaction implements AssetTransaction {
     }
 
     /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
+    /**
      * Get a hash of the transaction that doesn't contain the scripts. The hash
      * is used as a message to create a signature for a transaction.
      * @returns A hash.

--- a/src/core/transaction/IncreaseAssetSupply.ts
+++ b/src/core/transaction/IncreaseAssetSupply.ts
@@ -39,6 +39,14 @@ export class IncreaseAssetSupply extends Transaction {
         return new H256(blake256(this.transaction.rlpBytes()));
     }
 
+    /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
     public type(): string {
         return "increaseAssetSupply";
     }

--- a/src/core/transaction/MintAsset.ts
+++ b/src/core/transaction/MintAsset.ts
@@ -48,6 +48,14 @@ export class MintAsset extends Transaction implements AssetTransaction {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
+    /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
     public output(): AssetMintOutput {
         return this._transaction.output;
     }

--- a/src/core/transaction/TransferAsset.ts
+++ b/src/core/transaction/TransferAsset.ts
@@ -77,6 +77,14 @@ export class TransferAsset extends Transaction implements AssetTransaction {
     }
 
     /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(approval: string) {
+        this.approvals.push(approval);
+    }
+
+    /**
      * Add an AssetTransferInput to burn.
      * @param burns An array of either an AssetTransferInput or an Asset.
      * @returns The TransferAsset, which is modified by adding them.

--- a/src/core/transaction/UnwrapCCC.ts
+++ b/src/core/transaction/UnwrapCCC.ts
@@ -77,6 +77,14 @@ export class UnwrapCCC extends Transaction implements AssetTransaction {
         return new H256(blake256(this._transaction.rlpBytes()));
     }
 
+    /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(_approval: string) {
+        throw Error("Cannot approve UnwrapCCC");
+    }
+
     public type(): string {
         return "unwrapCCC";
     }

--- a/src/core/transaction/WrapCCC.ts
+++ b/src/core/transaction/WrapCCC.ts
@@ -107,6 +107,14 @@ export class WrapCCC extends Transaction implements AssetTransaction {
         return this.unsignedHash();
     }
 
+    /**
+     * Add an approval to transaction.
+     * @param approval An approval
+     */
+    public addApproval(_approval: string) {
+        throw Error("Cannot approve WrapCCC");
+    }
+
     public type(): string {
         return "wrapCCC";
     }

--- a/src/core/transaction/__test__/MintAsset.spec.ts
+++ b/src/core/transaction/__test__/MintAsset.spec.ts
@@ -1,0 +1,45 @@
+import { H160, U64 } from "codechain-primitives";
+import { SignedTransaction } from "../../SignedTransaction";
+import { AssetMintOutput } from "../AssetMintOutput";
+import { MintAsset } from "../MintAsset";
+
+function createMintAsset(): MintAsset {
+    return new MintAsset({
+        networkId: "tc",
+        shardId: 0,
+        metadata: "metadata",
+        output: new AssetMintOutput({
+            lockScriptHash: H160.zero(),
+            parameters: [],
+            supply: new U64(1)
+        }),
+        approver: null,
+        registrar: null,
+        allowedScriptHashes: [],
+        approvals: []
+    });
+}
+test("approval doesn't change the tracker", () => {
+    const t1 = createMintAsset();
+    const t2 = createMintAsset();
+    t2.addApproval("some approval");
+    expect(t1.tracker().value).toEqual(t2.tracker().value);
+});
+
+test("approval changes the hash", () => {
+    const t1 = createMintAsset();
+    const t2 = createMintAsset();
+    t2.addApproval("someone's approval");
+    expect((t1 as any).approvals).not.toEqual((t2 as any).approvals);
+
+    const fee = 10;
+    const seq = 20;
+    t1.setFee(fee);
+    t1.setSeq(seq);
+    t2.setFee(fee);
+    t2.setSeq(seq);
+
+    const signed1 = new SignedTransaction(t1, "signature");
+    const signed2 = new SignedTransaction(t2, "signature");
+    expect(signed1.hash().value).not.toEqual(signed2.hash().value);
+});

--- a/src/core/transaction/__test__/Pay.spec.ts
+++ b/src/core/transaction/__test__/Pay.spec.ts
@@ -1,7 +1,7 @@
 import { H256, PlatformAddress, U64 } from "codechain-primitives";
-import { Pay } from "../transaction/Pay";
+import { Pay } from "../Pay";
 
-import { fromJSONToTransaction } from "../transaction/json";
+import { fromJSONToTransaction } from "../json";
 
 test("rlp", () => {
     const t = new Pay(

--- a/src/core/transaction/__test__/TransferAsset.spec.ts
+++ b/src/core/transaction/__test__/TransferAsset.spec.ts
@@ -1,0 +1,39 @@
+import { SignedTransaction } from "../../SignedTransaction";
+import { TransferAsset } from "../TransferAsset";
+
+function createTransferAsset(): TransferAsset {
+    return new TransferAsset({
+        inputs: [],
+        burns: [],
+        outputs: [],
+        orders: [],
+        metadata: "metadata",
+        approvals: [],
+        expiration: null,
+        networkId: "tc"
+    });
+}
+test("approval doesn't change the tracker", () => {
+    const t1 = createTransferAsset();
+    const t2 = createTransferAsset();
+    t2.addApproval("some approval");
+    expect(t1.tracker().value).toEqual(t2.tracker().value);
+});
+
+test("approval changes the hash", () => {
+    const t1 = createTransferAsset();
+    const t2 = createTransferAsset();
+    t2.addApproval("someone's approval");
+    expect((t1 as any).approvals).not.toEqual((t2 as any).approvals);
+
+    const fee = 10;
+    const seq = 20;
+    t1.setFee(fee);
+    t1.setSeq(seq);
+    t2.setFee(fee);
+    t2.setSeq(seq);
+
+    const signed1 = new SignedTransaction(t1, "signature");
+    const signed2 = new SignedTransaction(t2, "signature");
+    expect(signed1.hash().value).not.toEqual(signed2.hash().value);
+});


### PR DESCRIPTION
Currently, there is no way to add approval to an asset transaction.