### PR TITLE
Change arguments of the sendRpcRequest() to be more flexible

### DIFF
--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -80,8 +80,13 @@ export class Rpc {
         this.devel = new DevelRpc(this);
     }
 
-    public sendRpcRequest = (name: string, params: any[], id?: string) => {
+    public sendRpcRequest = (
+        name: string,
+        params: any[],
+        options?: { id?: string }
+    ) => {
         return new Promise<any>((resolve, reject) => {
+            const { id } = options || { id: undefined };
             this.client.request(name, params, id, (err: any, res: any) => {
                 if (err) {
                     return reject(

--- a/src/rpc/node.ts
+++ b/src/rpc/node.ts
@@ -17,7 +17,7 @@ export class NodeRpc {
     public ping(id?: string): Promise<string> {
         return new Promise((resolve, reject) => {
             this.rpc
-                .sendRpcRequest("ping", [], id)
+                .sendRpcRequest("ping", [], { id })
                 .then(result => {
                     if (typeof result === "string") {
                         return resolve(result);


### PR DESCRIPTION
 Now the third argument of the sendRpcRequest() is changed to an optional object.
This patch improves the flexibility of the sendRpcRequest().