### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechain-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A JavaScript SDK for CodeChain",
   "scripts": {
     "lint": "tslint -p . && prettier '{src,examples,integration_tests}/**/*.{ts,js,json}' -l",


### PR DESCRIPTION
Breaking changes:
- Rename AssetTransferAddress to AssetAddress.
- Remove getAssetAddress() in MintAsset, TransferAsset, etc.