### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechain-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JavaScript SDK for CodeChain",
   "scripts": {
     "lint": "tslint -p . && prettier '{src,examples,integration_tests}/**/*.{ts,js,json}' -l",


### PR DESCRIPTION
- A seq field is added to AssetScheme.
- ChangeAssetScheme and IncreaseAssetSupply transactions now require a seq
  field. Its default value is 0.