### PR TITLE
Bump the version to 2.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechain-sdk",
-  "version": "1.2.1",
+  "version": "2.0.0-alpha.1",
   "description": "A JavaScript SDK for CodeChain",
   "scripts": {
     "lint": "tslint -p . && prettier '{src,examples,integration_tests}/**/*.{ts,js,json}' -l",


### PR DESCRIPTION
We need to update the sdk version for the codechain core to be able to use a new order implementation.