### PR TITLE
Bump the version to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "rlp": "^2.0.0"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.5",
     "@types/jest": "^23.3.1",
     "@types/lodash": "^4.14.108",
     "@types/node": "^9.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechain-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A JavaScript SDK for CodeChain",
   "scripts": {
     "lint": "tslint -p . && prettier '{src,examples,integration_tests}/**/*.{ts,js,json}' -l",


### PR DESCRIPTION
Bumped the version to 2.0.1, and removed `@types/bn.js` from the `devDependencies`.
See https://github.com/CodeChain-io/codechain-primitives-js/pull/71 for the reference.